### PR TITLE
fix: Edge-to-edge support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.activity:activity-ktx:1.11.0'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.4'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
@@ -36,14 +36,14 @@ class AppExporter(
     private var selectedAppInfoField: AppInfoField? = null
     private var currentExportType: String? = null
 
-    private val createFileLauncher: ActivityResultLauncher<Intent?>
+    private val createFileLauncher: ActivityResultLauncher<Intent>
 
     init {
-        this.createFileLauncher = activity.registerForActivityResult<Intent?, ActivityResult?>(
+        this.createFileLauncher = activity.registerForActivityResult(
             StartActivityForResult()
-        ) { result: ActivityResult? ->
-            if (result!!.resultCode == AppCompatActivity.RESULT_OK && result.data != null) {
-                val uri = result.data!!.data
+        ) { result ->
+        if (result.resultCode == AppCompatActivity.RESULT_OK && result.data != null) {
+                val uri = result.data?.data
                 if (uri != null) {
                     if ("xml" == currentExportType) {
                         writeXmlToFile(uri)
@@ -123,7 +123,7 @@ class AppExporter(
 
                 for (i in 0..<appInfoAdapter!!.itemCount) {
                     val app = appInfoAdapter.currentList[i]
-                    val appName = app.applicationInfo.loadLabel(packageManager!!).toString()
+                    val appName = app.applicationInfo.loadLabel(packageManager).toString()
                     val packageName = app.applicationInfo.packageName
                     val infoType = selectedAppInfoField!!.name
                     var infoValue: String? = ""
@@ -201,7 +201,7 @@ class AppExporter(
                 for (i in 0..<appInfoAdapter!!.itemCount) {
                     val app = appInfoAdapter.currentList[i]
                     val appName = Html.escapeHtml(
-                        app.applicationInfo.loadLabel(packageManager!!).toString()
+                        app.applicationInfo.loadLabel(packageManager).toString()
                     )
                     val packageName = Html.escapeHtml(app.applicationInfo.packageName)
 

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -17,6 +17,7 @@ import android.widget.ArrayAdapter
 import android.widget.ProgressBar
 import android.widget.Spinner
 import android.widget.ToggleButton
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.lifecycle.ViewModelProvider
@@ -41,6 +42,7 @@ class MainActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener, Ap
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContentView(R.layout.activity_main)
 
         if (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES) {


### PR DESCRIPTION
Android vitals reported these two issues.

## Edge-to-edge may not display for all users

From Android 15, apps targeting SDK 35 will display edge-to-edge by default. Apps targeting SDK 35 should handle insets to make sure that their app displays correctly on Android 15 and later. Investigate this issue and allow time to test edge-to-edge and make the required updates. Alternatively, call enableEdgeToEdge() for Kotlin or EdgeToEdge.enable() for Java for backward compatibility.

## Your app uses deprecated APIs or parameters for edge-to-edge

One or more of the APIs you use or parameters that you set for edge-to-edge and window display have been deprecated in Android 15. Your app uses the following deprecated APIs or parameters:

* `android.view.Window.setStatusBarColor`
* `android.view.Window.setNavigationBarColor`

These start in the following places:

* `com.google.android.material.bottomsheet.BottomSheetDialog.onCreate`
* `com.google.android.material.internal.EdgeToEdgeUtils.applyEdgeToEdge`
* `com.google.android.material.sidesheet.SheetDialog.onCreate`

To fix this, migrate away from these APIs or parameters.