### PR TITLE
fix: Crash

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.AppList.Settings" parent="Theme.Material3.DayNight.NoActionBar" />
+    <style name="Theme.AppList.Settings" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.github.keeganwitt.applist/com.github.keeganwitt.applist.SettingsActivity}
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4496)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4699)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:224)
       at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:133)
       at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:103)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2961)
       at android.os.Handler.dispatchMessage(Handler.java:132)
       at android.os.Looper.dispatchMessage(Looper.java:333)
       at android.os.Looper.loopOnce(Looper.java:263)
       at android.os.Looper.loop(Looper.java:367)
       at android.app.ActivityThread.main(ActivityThread.java:9282)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)

Caused by java.lang.IllegalStateException: This Activity already has an action bar supplied by the window decor. Do not request Window.FEATURE_SUPPORT_ACTION_BAR and set windowActionBar to false in your theme to use a Toolbar instead.
       at androidx.appcompat.app.AppCompatDelegateImpl.setSupportActionBar(AppCompatDelegateImpl.java:606)
       at androidx.appcompat.app.AppCompatActivity.setSupportActionBar(AppCompatActivity.java:181)
       at com.github.keeganwitt.applist.SettingsActivity.onCreate(SettingsActivity.kt:19)
       at android.app.Activity.performCreate(Activity.java:9306)
       at android.app.Activity.performCreate(Activity.java:9284)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1541)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4480)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4699)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:224)
       at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:133)
       at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:103)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2961)
       at android.os.Handler.dispatchMessage(Handler.java:132)
       at android.os.Looper.dispatchMessage(Looper.java:333)
       at android.os.Looper.loopOnce(Looper.java:263)
       at android.os.Looper.loop(Looper.java:367)
       at android.app.ActivityThread.main(ActivityThread.java:9282)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

Gemini has analyzed the stack trace and other metrics, and here's the analysis:

This `IllegalStateException` indicates a conflict in how the Activity is trying to manage its Action Bar. Specifically, the Android framework (or a library/theme) has already provided an Action Bar to the `SettingsActivity` through the window's decor, but the code is also attempting to explicitly request `Window.FEATURE_SUPPORT_ACTION_BAR` and then set `windowActionBar` to `false` in the theme while simultaneously trying to use a Toolbar as the Action Bar.

The root cause is an attempt to configure the Action Bar both implicitly (via the theme's `windowActionBar` property set to false indicating a custom Toolbar will be used) and explicitly (by calling `requestWindowFeature(Window.FEATURE_SUPPORT_ACTION_BAR)` ), or by having a theme that implicitly provides an Action Bar while also trying to set a custom Toolbar via `setSupportActionBar()`. The message explicitly states that if you want to use a Toolbar as your Action Bar, you should not request `Window.FEATURE_SUPPORT_ACTION_BAR` and must set `windowActionBar` to `false` in your theme.

### Debugging and Resolution:

1. **Examine `SettingsActivity.kt` and its Layout:**
    * **`onCreate` Method:** Look for calls to requestWindowFeature(Window.FEATURE_SUPPORT_ACTION_BAR) or setSupportActionBar(toolbar) within the onCreate method of SettingsActivity . If requestWindowFeature is present, it's likely redundant or conflicting if a Toolbar is also being used.
    * **Layout XML:** Check the layout file associated with SettingsActivity (e.g., activity_settings.xml ). Does it include a androidx.appcompat.widget.Toolbar ? If so, this Toolbar is intended to replace the default Action Bar.
2. **Inspect the Activity's Theme:**
    * **`AndroidManifest.xml`:** Locate the SettingsActivity entry in your AndroidManifest.xml . Check the android:theme attribute for this activity.
    * **Theme Definition:** Navigate to the specified theme (e.g., `res/values/styles.xml` or `res/values/themes.xml`).
    * **`windowActionBar` and `windowNoTitle`:** Look for the following attributes within the theme:
      * **`android:windowActionBar`:** This should be false if you are using a Toolbar as your Action Bar.
      * **`android:windowNoTitle`:** This should also be false if you are using a Toolbar and want it to display a title.
      * **`android:windowNoTitle`:** If you are using a Toolbar and it's intended to replace the system's title bar, this should be `true`.
    * **`Theme.AppCompat.NoActionBar`:** If the activity's theme inherits from `Theme.AppCompat.NoActionBar` (or a similar `NoActionBar` theme), it inherently sets `windowActionBar` to `false` and `windowNoTitle` to `true` . In this case, explicitly calling `requestWindowFeature` is definitely an error.

### Actionable Next Step:

The most likely conflict arises from incorrect theme configuration combined with attempting to explicitly manage the Action Bar.
* **If you intend to use `Toolbar` as your Action Bar:**
  1. Remove `requestWindowFeature(Window.FEATURE_SUPPORT_ACTION_BAR)` from `SettingsActivity.onCreate()`. This call is generally not needed when using Toolbar from `androidx.appcompat.widget`.
  1. Ensure the Activity's theme inherits from a `NoActionBar` theme. For example, `Theme.AppCompat.Light.NoActionBar` or a custom theme that sets `windowActionBar` to `false` and `windowNoTitle` to `true` . This tells the system not to provide its default Action Bar, allowing your `Toolbar` to take its place.
  1. Call `setSupportActionBar(toolbar)` in `SettingsActivity.onCreate()` after `setContentView()` and after you've inflated or found your Toolbar view.

### Best Practices to Avoid Such Issues:

* **Consistency in Action Bar Management:** Decide early whether you will use the default `ActionBar` provided by the theme or a custom `Toolbar`. Do not mix and match.
* **Use NoActionBar Themes for Custom Toolbars:** When you want to use a `androidx.appcompat.widget.Toolbar` as your Activity's Action Bar, always use a theme that inherits from `Theme.AppCompat.NoActionBar` (or similar) for that specific Activity. This prevents the system from creating its own default Action Bar, avoiding conflicts.
* **`requestWindowFeature` Usage:** `requestWindowFeature()` should generally be called before `super.onCreate()` and before `setContentView()`. However, for `ActionBar` related features, with modern Toolbar usage, it's often not necessary and can lead to conflicts. If you're using `AppCompatActivity`, the `ActionBar` features are handled internally, and explicit calls to `requestWindowFeature` for Action Bar support are usually discouraged.
* **Clear Separation of Concerns:** Your theme should dictate whether a default Action Bar is present. Your Activity code should then either interact with the provided `getSupportActionBar()` or set up a custom Toolbar using `setSupportActionBar()`, but not both in a conflicting manner.
* **Review Library Code (if applicable):** If the `SettingsActivity` is part of a library (com.github.keeganwitt.applist in this case), inspect how the library itself handles Action Bar setup. It's possible the library expects a specific theme or doesn't support explicit `requestWindowFeature` calls from the consuming application. If the library itself is causing the conflict, you might need to adjust your theme to match its expectations or, as a last resort, fork the library and modify it.