### PR TITLE
Remove unused loadIcon from PackageService

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/services/PackageService.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/services/PackageService.kt
@@ -16,8 +16,6 @@ interface PackageService {
 
     fun loadLabel(applicationInfo: ApplicationInfo): String
 
-    fun loadIcon(applicationInfo: ApplicationInfo): Drawable
-
     @Throws(PackageManager.NameNotFoundException::class)
     fun getPackageInfo(applicationInfo: ApplicationInfo): PackageInfo
 
@@ -43,8 +41,6 @@ class AndroidPackageService(
     override fun getLaunchIntentForPackage(packageName: String): android.content.Intent? = pm.getLaunchIntentForPackage(packageName)
 
     override fun loadLabel(applicationInfo: ApplicationInfo): String = applicationInfo.loadLabel(pm).toString()
-
-    override fun loadIcon(applicationInfo: ApplicationInfo): Drawable = pm.getApplicationIcon(applicationInfo)
 
     override fun getPackageInfo(applicationInfo: ApplicationInfo): PackageInfo {
         var flags = PackageManager.GET_PERMISSIONS.toLong()

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/services/PackageServiceTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/services/PackageServiceTest.kt
@@ -80,17 +80,6 @@ class PackageServiceTest {
     }
 
     @Test
-    fun `given application info, when loadIcon called, then returns drawable`() {
-        val appInfo = mockk<ApplicationInfo>()
-        val drawable = mockk<Drawable>()
-        every { packageManager.getApplicationIcon(appInfo) } returns drawable
-
-        val result = service.loadIcon(appInfo)
-
-        assertNotNull(result)
-    }
-
-    @Test
     fun `given application info, when getPackageInfo called, then returns package info`() {
         val appInfo = ApplicationInfo().apply { packageName = "com.test.app" }
         val packageInfo = PackageInfo().apply { versionName = "1.0.0" }


### PR DESCRIPTION
Removed `loadIcon(ApplicationInfo)` from `PackageService` interface and its implementation in `AndroidPackageService`.
Removed the corresponding unit test in `PackageServiceTest`.

This improves code health by removing dead code.
Verified by running `./gradlew testDebugUnitTest`.

---
*PR created automatically by Jules for task [7981589922740730485](https://jules.google.com/task/7981589922740730485) started by @keeganwitt*