### PR TITLE
Remove unused getInstalledApplications(Int)

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/services/PackageService.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/services/PackageService.kt
@@ -8,8 +8,6 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 
 interface PackageService {
-    fun getInstalledApplications(flags: Int): List<ApplicationInfo>
-
     fun getInstalledApplications(flags: Long): List<ApplicationInfo>
 
     fun getLaunchIntentForPackage(packageName: String): android.content.Intent?
@@ -30,8 +28,6 @@ class AndroidPackageService(
     context: Context,
 ) : PackageService {
     private val pm: PackageManager = context.packageManager
-
-    override fun getInstalledApplications(flags: Int): List<ApplicationInfo> = pm.getInstalledPackages(flags).map { it.applicationInfo!! }
 
     override fun getInstalledApplications(flags: Long): List<ApplicationInfo> =
         if (Build.VERSION.SDK_INT >= 33) {

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/services/PackageServiceTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/services/PackageServiceTest.kt
@@ -43,7 +43,7 @@ class PackageServiceTest {
 
         every { packageManager.getInstalledPackages(any<Int>()) } returns packages
 
-        val result = service.getInstalledApplications(PackageManager.GET_META_DATA)
+        val result = service.getInstalledApplications(PackageManager.GET_META_DATA.toLong())
 
         assertEquals(2, result.size)
         assertEquals("com.test.app1", result[0].packageName)


### PR DESCRIPTION
Removed unused `getInstalledApplications(Int)` from `PackageService` and updated tests.

---
*PR created automatically by Jules for task [3562678725399911094](https://jules.google.com/task/3562678725399911094) started by @keeganwitt*