### PR TITLE
Refactor AppInfoField Logic to Enum

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppInfoField.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppInfoField.kt
@@ -1,24 +1,79 @@
 package com.github.keeganwitt.applist
 
+import java.text.DateFormat
+import java.util.Date
+
 enum class AppInfoField(
     val titleResId: Int,
 ) {
-    APK_SIZE(R.string.appInfoField_apkSize),
-    APP_SIZE(R.string.appInfoField_appSize),
-    ARCHIVED(R.string.appInfoField_archived),
-    CACHE_SIZE(R.string.appInfoField_cacheSize),
-    DATA_SIZE(R.string.appInfoField_dataSize),
-    ENABLED(R.string.appInfoField_enabled),
-    EXISTS_IN_APP_STORE(R.string.appInfoField_exists_in_app_store),
-    EXTERNAL_CACHE_SIZE(R.string.appInfoField_externalCacheSize),
-    FIRST_INSTALLED(R.string.appInfoField_firstInstalled),
-    GRANTED_PERMISSIONS(R.string.appInfoField_grantedPermissions),
-    LAST_UPDATED(R.string.appInfoField_lastUpdated),
-    LAST_USED(R.string.appInfoField_lastUsed),
-    MIN_SDK(R.string.appInfoField_minSdk),
-    PACKAGE_MANAGER(R.string.appInfoField_packageManager),
-    REQUESTED_PERMISSIONS(R.string.appInfoField_requestedPermissions),
-    TARGET_SDK(R.string.appInfoField_targetSdk),
-    TOTAL_SIZE(R.string.appInfoField_totalSize),
-    VERSION(R.string.appInfoField_version),
+    APK_SIZE(R.string.appInfoField_apkSize) {
+        override fun getValue(app: App) = app.sizes.apkBytes
+    },
+    APP_SIZE(R.string.appInfoField_appSize) {
+        override fun getValue(app: App) = app.sizes.appBytes
+    },
+    ARCHIVED(R.string.appInfoField_archived) {
+        override fun getValue(app: App) = app.archived ?: false
+        override fun getFormattedValue(app: App) = (app.archived ?: false).toString()
+    },
+    CACHE_SIZE(R.string.appInfoField_cacheSize) {
+        override fun getValue(app: App) = app.sizes.cacheBytes
+    },
+    DATA_SIZE(R.string.appInfoField_dataSize) {
+        override fun getValue(app: App) = app.sizes.dataBytes
+    },
+    ENABLED(R.string.appInfoField_enabled) {
+        override fun getValue(app: App) = app.enabled
+        override fun getFormattedValue(app: App) = app.enabled.toString()
+    },
+    EXISTS_IN_APP_STORE(R.string.appInfoField_exists_in_app_store) {
+        override fun getValue(app: App) = app.existsInStore ?: false
+        override fun getFormattedValue(app: App) = (app.existsInStore ?: false).toString()
+    },
+    EXTERNAL_CACHE_SIZE(R.string.appInfoField_externalCacheSize) {
+        override fun getValue(app: App) = app.sizes.externalCacheBytes
+    },
+    FIRST_INSTALLED(R.string.appInfoField_firstInstalled) {
+        override fun getValue(app: App) = app.firstInstalled
+        override fun getFormattedValue(app: App) =
+            app.firstInstalled?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
+    },
+    GRANTED_PERMISSIONS(R.string.appInfoField_grantedPermissions) {
+        override fun getValue(app: App) = app.grantedPermissionsCount ?: 0
+    },
+    LAST_UPDATED(R.string.appInfoField_lastUpdated) {
+        override fun getValue(app: App) = app.lastUpdated
+        override fun getFormattedValue(app: App) =
+            app.lastUpdated?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
+    },
+    LAST_USED(R.string.appInfoField_lastUsed) {
+        override fun getValue(app: App) = app.lastUsed
+        override fun getFormattedValue(app: App) =
+            app.lastUsed?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
+    },
+    MIN_SDK(R.string.appInfoField_minSdk) {
+        override fun getValue(app: App) = app.minSdk ?: 0
+        override fun getFormattedValue(app: App) = app.minSdk?.toString() ?: ""
+    },
+    PACKAGE_MANAGER(R.string.appInfoField_packageManager) {
+        override fun getValue(app: App) = app.installerName ?: ""
+    },
+    REQUESTED_PERMISSIONS(R.string.appInfoField_requestedPermissions) {
+        override fun getValue(app: App) = app.requestedPermissionsCount ?: 0
+    },
+    TARGET_SDK(R.string.appInfoField_targetSdk) {
+        override fun getValue(app: App) = app.targetSdk ?: 0
+        override fun getFormattedValue(app: App) = app.targetSdk?.toString() ?: ""
+    },
+    TOTAL_SIZE(R.string.appInfoField_totalSize) {
+        override fun getValue(app: App) = app.sizes.totalBytes
+    },
+    VERSION(R.string.appInfoField_version) {
+        override fun getValue(app: App) = app.versionName ?: ""
+    },
+    ;
+
+    abstract fun getValue(app: App): Comparable<*>?
+
+    open fun getFormattedValue(app: App): String = getValue(app)?.toString() ?: ""
 }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -9,9 +9,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.text.DateFormat
-import java.util.Date
-
 class AppListViewModel(
     private val repository: AppRepository,
     private val dispatchers: DispatcherProvider,
@@ -104,27 +101,7 @@ class AppListViewModel(
         app: App,
         field: AppInfoField,
     ): AppItemUiModel {
-        val info =
-            when (field) {
-                AppInfoField.APK_SIZE -> app.sizes.apkBytes.toString()
-                AppInfoField.APP_SIZE -> app.sizes.appBytes.toString()
-                AppInfoField.CACHE_SIZE -> app.sizes.cacheBytes.toString()
-                AppInfoField.DATA_SIZE -> app.sizes.dataBytes.toString()
-                AppInfoField.ENABLED -> app.enabled.toString()
-                AppInfoField.ARCHIVED -> (app.archived ?: false).toString()
-                AppInfoField.EXISTS_IN_APP_STORE -> (app.existsInStore ?: false).toString()
-                AppInfoField.EXTERNAL_CACHE_SIZE -> app.sizes.externalCacheBytes.toString()
-                AppInfoField.FIRST_INSTALLED -> app.firstInstalled?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
-                AppInfoField.LAST_UPDATED -> app.lastUpdated?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
-                AppInfoField.LAST_USED -> app.lastUsed?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
-                AppInfoField.MIN_SDK -> app.minSdk?.toString() ?: ""
-                AppInfoField.PACKAGE_MANAGER -> app.installerName ?: ""
-                AppInfoField.GRANTED_PERMISSIONS -> app.grantedPermissionsCount?.toString() ?: "0"
-                AppInfoField.REQUESTED_PERMISSIONS -> app.requestedPermissionsCount?.toString() ?: "0"
-                AppInfoField.TARGET_SDK -> app.targetSdk?.toString() ?: ""
-                AppInfoField.TOTAL_SIZE -> app.sizes.totalBytes.toString()
-                AppInfoField.VERSION -> app.versionName ?: ""
-            }
+        val info = field.getFormattedValue(app)
         return AppItemUiModel(
             packageName = app.packageName,
             appName = app.name,

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
@@ -164,27 +164,7 @@ class AndroidAppRepository(
     private fun sortKey(
         app: App,
         field: AppInfoField,
-    ): Comparable<*>? =
-        when (field) {
-            AppInfoField.APK_SIZE -> app.sizes.apkBytes
-            AppInfoField.APP_SIZE -> app.sizes.appBytes
-            AppInfoField.CACHE_SIZE -> app.sizes.cacheBytes
-            AppInfoField.DATA_SIZE -> app.sizes.dataBytes
-            AppInfoField.ENABLED -> app.enabled.toString()
-            AppInfoField.ARCHIVED -> app.archived ?: false
-            AppInfoField.EXISTS_IN_APP_STORE -> app.existsInStore ?: false
-            AppInfoField.EXTERNAL_CACHE_SIZE -> app.sizes.externalCacheBytes
-            AppInfoField.FIRST_INSTALLED -> app.firstInstalled
-            AppInfoField.LAST_UPDATED -> app.lastUpdated
-            AppInfoField.LAST_USED -> app.lastUsed
-            AppInfoField.MIN_SDK -> app.minSdk ?: 0
-            AppInfoField.PACKAGE_MANAGER -> app.installerName ?: ""
-            AppInfoField.GRANTED_PERMISSIONS -> app.grantedPermissionsCount ?: 0
-            AppInfoField.REQUESTED_PERMISSIONS -> app.requestedPermissionsCount ?: 0
-            AppInfoField.TARGET_SDK -> app.targetSdk ?: 0
-            AppInfoField.TOTAL_SIZE -> app.sizes.totalBytes
-            AppInfoField.VERSION -> app.versionName ?: ""
-        }
+    ): Comparable<*>? = field.getValue(app)
 
     // Copy of Android's flag to avoid direct dependency on PackageInfo in signature
     private companion object {

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppInfoFieldTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppInfoFieldTest.kt
@@ -3,6 +3,8 @@ package com.github.keeganwitt.applist
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import java.text.DateFormat
+import java.util.Date
 
 class AppInfoFieldTest {
     @Test
@@ -137,5 +139,169 @@ class AppInfoFieldTest {
         val resourceIds = AppInfoField.entries.map { it.titleResId }.toSet()
 
         assertEquals(AppInfoField.entries.size, resourceIds.size)
+    }
+
+    @Test
+    fun `given App with data, when getValue called, then correct value returned`() {
+        val storage =
+            StorageUsage().apply {
+                apkBytes = 100
+                appBytes = 200
+                cacheBytes = 300
+                dataBytes = 400
+                externalCacheBytes = 500
+            }
+        val app =
+            App(
+                packageName = "com.test",
+                name = "Test App",
+                versionName = "1.0",
+                archived = true,
+                minSdk = 24,
+                targetSdk = 33,
+                firstInstalled = 1000L,
+                lastUpdated = 2000L,
+                lastUsed = 3000L,
+                sizes = storage,
+                installerName = "Installer",
+                existsInStore = true,
+                grantedPermissionsCount = 5,
+                requestedPermissionsCount = 10,
+                enabled = true,
+            )
+
+        assertEquals(100L, AppInfoField.APK_SIZE.getValue(app))
+        assertEquals(200L, AppInfoField.APP_SIZE.getValue(app))
+        assertEquals(300L, AppInfoField.CACHE_SIZE.getValue(app))
+        assertEquals(400L, AppInfoField.DATA_SIZE.getValue(app))
+        assertEquals(500L, AppInfoField.EXTERNAL_CACHE_SIZE.getValue(app))
+        assertEquals(storage.totalBytes, AppInfoField.TOTAL_SIZE.getValue(app))
+
+        assertEquals(true, AppInfoField.ARCHIVED.getValue(app))
+        assertEquals(true, AppInfoField.ENABLED.getValue(app))
+        assertEquals(true, AppInfoField.EXISTS_IN_APP_STORE.getValue(app))
+
+        assertEquals(1000L, AppInfoField.FIRST_INSTALLED.getValue(app))
+        assertEquals(2000L, AppInfoField.LAST_UPDATED.getValue(app))
+        assertEquals(3000L, AppInfoField.LAST_USED.getValue(app))
+
+        assertEquals(24, AppInfoField.MIN_SDK.getValue(app))
+        assertEquals(33, AppInfoField.TARGET_SDK.getValue(app))
+
+        assertEquals("Installer", AppInfoField.PACKAGE_MANAGER.getValue(app))
+        assertEquals("1.0", AppInfoField.VERSION.getValue(app))
+
+        assertEquals(5, AppInfoField.GRANTED_PERMISSIONS.getValue(app))
+        assertEquals(10, AppInfoField.REQUESTED_PERMISSIONS.getValue(app))
+    }
+
+    @Test
+    fun `given App with nulls, when getValue called, then defaults returned`() {
+        val app =
+            App(
+                packageName = "com.test",
+                name = "Test App",
+                versionName = null,
+                archived = null,
+                minSdk = null,
+                targetSdk = null,
+                firstInstalled = null,
+                lastUpdated = null,
+                lastUsed = null,
+                sizes = StorageUsage(),
+                installerName = null,
+                existsInStore = null,
+                grantedPermissionsCount = null,
+                requestedPermissionsCount = null,
+                enabled = false,
+            )
+
+        assertEquals(false, AppInfoField.ARCHIVED.getValue(app))
+        assertEquals(false, AppInfoField.EXISTS_IN_APP_STORE.getValue(app))
+
+        assertEquals(0, AppInfoField.MIN_SDK.getValue(app))
+        assertEquals(0, AppInfoField.TARGET_SDK.getValue(app))
+
+        assertEquals("", AppInfoField.PACKAGE_MANAGER.getValue(app))
+        assertEquals("", AppInfoField.VERSION.getValue(app))
+
+        assertEquals(0, AppInfoField.GRANTED_PERMISSIONS.getValue(app))
+        assertEquals(0, AppInfoField.REQUESTED_PERMISSIONS.getValue(app))
+    }
+
+    @Test
+    fun `given App with data, when getFormattedValue called, then correct string returned`() {
+        val storage =
+            StorageUsage().apply {
+                apkBytes = 100
+            }
+        val app =
+            App(
+                packageName = "com.test",
+                name = "Test App",
+                versionName = "1.0",
+                archived = true,
+                minSdk = 24,
+                targetSdk = 33,
+                firstInstalled = 1000L,
+                lastUpdated = 2000L,
+                lastUsed = 3000L,
+                sizes = storage,
+                installerName = "Installer",
+                existsInStore = true,
+                grantedPermissionsCount = 5,
+                requestedPermissionsCount = 10,
+                enabled = true,
+            )
+
+        assertEquals("100", AppInfoField.APK_SIZE.getFormattedValue(app))
+        assertEquals("true", AppInfoField.ARCHIVED.getFormattedValue(app))
+        assertEquals("true", AppInfoField.ENABLED.getFormattedValue(app))
+        assertEquals("true", AppInfoField.EXISTS_IN_APP_STORE.getFormattedValue(app))
+        assertEquals("24", AppInfoField.MIN_SDK.getFormattedValue(app))
+        assertEquals("33", AppInfoField.TARGET_SDK.getFormattedValue(app))
+        assertEquals("Installer", AppInfoField.PACKAGE_MANAGER.getFormattedValue(app))
+        assertEquals("1.0", AppInfoField.VERSION.getFormattedValue(app))
+        assertEquals("5", AppInfoField.GRANTED_PERMISSIONS.getFormattedValue(app))
+        assertEquals("10", AppInfoField.REQUESTED_PERMISSIONS.getFormattedValue(app))
+
+        val dateFormat = DateFormat.getDateTimeInstance()
+        assertEquals(dateFormat.format(Date(1000L)), AppInfoField.FIRST_INSTALLED.getFormattedValue(app))
+    }
+
+    @Test
+    fun `given App with nulls, when getFormattedValue called, then empty strings returned for optional fields`() {
+        val app =
+            App(
+                packageName = "com.test",
+                name = "Test App",
+                versionName = null,
+                archived = null,
+                minSdk = null,
+                targetSdk = null,
+                firstInstalled = null,
+                lastUpdated = null,
+                lastUsed = null,
+                sizes = StorageUsage(),
+                installerName = null,
+                existsInStore = null,
+                grantedPermissionsCount = null,
+                requestedPermissionsCount = null,
+                enabled = false,
+            )
+
+        assertEquals("false", AppInfoField.ARCHIVED.getFormattedValue(app)) // false.toString()
+        assertEquals("false", AppInfoField.EXISTS_IN_APP_STORE.getFormattedValue(app)) // false.toString()
+
+        assertEquals("", AppInfoField.MIN_SDK.getFormattedValue(app))
+        assertEquals("", AppInfoField.TARGET_SDK.getFormattedValue(app))
+        assertEquals("", AppInfoField.FIRST_INSTALLED.getFormattedValue(app))
+        assertEquals("", AppInfoField.LAST_UPDATED.getFormattedValue(app))
+        assertEquals("", AppInfoField.LAST_USED.getFormattedValue(app))
+        assertEquals("", AppInfoField.PACKAGE_MANAGER.getFormattedValue(app))
+        assertEquals("", AppInfoField.VERSION.getFormattedValue(app))
+
+        assertEquals("0", AppInfoField.GRANTED_PERMISSIONS.getFormattedValue(app))
+        assertEquals("0", AppInfoField.REQUESTED_PERMISSIONS.getFormattedValue(app))
     }
 }


### PR DESCRIPTION
Refactored `AppInfoField` to encapsulate logic for retrieving and formatting app information. This change moves the `when` expressions from `AppRepository` (for sorting) and `AppListViewModel` (for display) into the enum itself, implementing the "Replace Conditional with Polymorphism" pattern.

Changes:
- added `getValue(app: App): Comparable<*>?` to `AppInfoField`.
- added `getFormattedValue(app: App): String` to `AppInfoField`.
- Implemented specific logic for each enum constant.
- Refactored `AppRepository.sortKey` to use `field.getValue(app)`.
- Refactored `AppListViewModel.mapToItem` to use `field.getFormattedValue(app)`.
- Added unit tests in `AppInfoFieldTest` to verify correctness of value retrieval and formatting.
- Verified that existing tests in `AppRepositoryTest` and `AppListViewModelTest` pass.

---
*PR created automatically by Jules for task [16434196514740094622](https://jules.google.com/task/16434196514740094622) started by @keeganwitt*