### PR TITLE
🧹 Migrate MainActivity to ViewBinding

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -13,10 +13,7 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import android.widget.ProgressBar
-import android.widget.Spinner
 import android.widget.Toast
-import android.widget.ToggleButton
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
@@ -27,8 +24,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.github.keeganwitt.applist.databinding.ActivityMainBinding
 import com.github.keeganwitt.applist.services.AndroidPackageService
 import com.github.keeganwitt.applist.services.AndroidStorageService
 import com.github.keeganwitt.applist.services.AndroidUsageStatsService
@@ -44,11 +40,7 @@ class MainActivity :
     AppAdapter.OnClickListener {
     private lateinit var appInfoFields: List<AppInfoField>
     private lateinit var appAdapter: AppAdapter
-    private lateinit var spinner: Spinner
-    private lateinit var toggleButton: ToggleButton
-    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var progressBar: ProgressBar
+    private lateinit var binding: ActivityMainBinding
     private var showSystemApps = false
     private lateinit var appExporter: AppExporter
     private lateinit var appListViewModel: AppListViewModel
@@ -60,7 +52,8 @@ class MainActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
         val isLightMode =
@@ -89,17 +82,11 @@ class MainActivity :
         androidx.appcompat.app.AppCompatDelegate
             .setDefaultNightMode(nightMode)
 
-        progressBar = findViewById(R.id.progress_bar)
-        recyclerView = findViewById(R.id.recycler_view)
-        spinner = findViewById(R.id.spinner)
-        toggleButton = findViewById(R.id.toggleButton)
-        swipeRefreshLayout = findViewById(R.id.swipeRefreshLayout)
-
         val packageService = AndroidPackageService(applicationContext)
         val iconLoader = IconLoader(packageService)
         appAdapter = AppAdapter(this, this, iconLoader)
-        recyclerView.layoutManager = GridAutofitLayoutManager(this, 450)
-        recyclerView.adapter = appAdapter
+        binding.recyclerView.layoutManager = GridAutofitLayoutManager(this, 450)
+        binding.recyclerView.adapter = appAdapter
 
         val crashReporter = FirebaseCrashReporter()
         appExporter =
@@ -145,22 +132,22 @@ class MainActivity :
         val arrayAdapter =
             ArrayAdapter(this, android.R.layout.simple_spinner_item, appInfoFieldStrings)
         arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        spinner.adapter = arrayAdapter
+        binding.spinner.adapter = arrayAdapter
 
         // initial selection to VERSION
         val lastDisplayedField = appSettings.getLastDisplayedAppInfoField()
         val initialLabel =
             fieldToLabelMap[lastDisplayedField] ?: getString(R.string.appInfoField_version)
         val initialIndex = appInfoFieldStrings.indexOf(initialLabel).coerceAtLeast(0)
-        spinner.setSelection(initialIndex, false)
-        spinner.onItemSelectedListener = this
+        binding.spinner.setSelection(initialIndex, false)
+        binding.spinner.onItemSelectedListener = this
         appListViewModel.init(lastDisplayedField)
 
-        toggleButton.setOnCheckedChangeListener { _, _ -> appListViewModel.toggleDescending() }
+        binding.toggleButton.setOnCheckedChangeListener { _, _ -> appListViewModel.toggleDescending() }
 
-        swipeRefreshLayout.setOnRefreshListener {
+        binding.swipeRefreshLayout.setOnRefreshListener {
             appListViewModel.refresh()
-            swipeRefreshLayout.isRefreshing = false
+            binding.swipeRefreshLayout.isRefreshing = false
         }
     }
 
@@ -170,8 +157,8 @@ class MainActivity :
                 appListViewModel.uiState.collectLatest { state ->
                     latestState = state
                     appAdapter.submitList(state.items)
-                    progressBar.visibility = if (state.isLoading) View.VISIBLE else View.GONE
-                    recyclerView.visibility = if (state.isLoading) View.GONE else View.VISIBLE
+                    binding.progressBar.visibility = if (state.isLoading) View.VISIBLE else View.GONE
+                    binding.recyclerView.visibility = if (state.isLoading) View.GONE else View.VISIBLE
                 }
             }
         }
@@ -224,12 +211,12 @@ class MainActivity :
     }
 
     override fun onNothingSelected(parent: AdapterView<*>) {
-        val adapter = spinner.adapter
+        val adapter = binding.spinner.adapter
         val versionText = getString(R.string.appInfoField_version)
         val versionIndex =
             (0 until adapter.count).firstOrNull { adapter.getItem(it) == versionText }
         if (versionIndex != null) {
-            spinner.setSelection(versionIndex)
+            binding.spinner.setSelection(versionIndex)
         }
         appListViewModel.updateSelectedField(AppInfoField.VERSION)
     }


### PR DESCRIPTION
This PR migrates `MainActivity` to use ViewBinding.
It replaces manual `findViewById` calls with the generated binding class `ActivityMainBinding`.
This refactoring improves type safety and reduces boilerplate code in the activity.
Verified by running `./gradlew lintDebug` and `./gradlew testDebugUnitTest`.

---
*PR created automatically by Jules for task [11480128353064783249](https://jules.google.com/task/11480128353064783249) started by @keeganwitt*