### PR TITLE
🔒 Fix tapjacking vulnerability in main and settings activities

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,6 +3,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/swipeRefreshLayout"
+  android:filterTouchesWhenObscured="true"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:fitsSystemWindows="true"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
+    android:filterTouchesWhenObscured="true"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.AppBarLayout

--- a/app/src/main/res/layout/dialog_export_type.xml
+++ b/app/src/main/res/layout/dialog_export_type.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:filterTouchesWhenObscured="true"
     android:orientation="vertical"
     android:padding="16dp">
 

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/TapjackingProtectionTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/TapjackingProtectionTest.kt
@@ -1,0 +1,46 @@
+package com.github.keeganwitt.applist
+
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class TapjackingProtectionTest {
+
+    @Test
+    fun `activity_main layout should have filterTouchesWhenObscured set to true`() {
+        val context = ApplicationProvider.getApplicationContext<AppListApplication>()
+        val inflater = LayoutInflater.from(context)
+        val view = inflater.inflate(R.layout.activity_main, null)
+
+        assertTrue("activity_main.xml root view should filter touches when obscured", view.filterTouchesWhenObscured)
+    }
+
+    @Test
+    fun `activity_settings layout should have filterTouchesWhenObscured set to true`() {
+        // MaterialToolbar requires a valid Material theme
+        val context = ContextThemeWrapper(
+            ApplicationProvider.getApplicationContext(),
+            R.style.Theme_AppList_Settings
+        )
+        val inflater = LayoutInflater.from(context)
+        val view = inflater.inflate(R.layout.activity_settings, null)
+
+        assertTrue("activity_settings.xml root view should filter touches when obscured", view.filterTouchesWhenObscured)
+    }
+
+    @Test
+    fun `dialog_export_type layout should have filterTouchesWhenObscured set to true`() {
+        val context = ApplicationProvider.getApplicationContext<AppListApplication>()
+        val inflater = LayoutInflater.from(context)
+        val view = inflater.inflate(R.layout.dialog_export_type, null)
+
+        assertTrue("dialog_export_type.xml root view should filter touches when obscured", view.filterTouchesWhenObscured)
+    }
+}


### PR DESCRIPTION
This PR addresses a potential tapjacking vulnerability by adding `android:filterTouchesWhenObscured="true"` to the root layouts of `MainActivity`, `SettingsActivity`, and the export type dialog. This attribute ensures that touches are ignored if the view is obscured by another window, preventing malicious apps from tricking users into performing unintended actions.

A new Robolectric test `TapjackingProtectionTest` has been added to verify that the attribute is present on the inflated views. All existing tests pass.

---
*PR created automatically by Jules for task [17431326924794842976](https://jules.google.com/task/17431326924794842976) started by @keeganwitt*