### PR TITLE
test: Add invalid value tests for AppSettings

### DIFF
--- a/app/src/test/kotlin/com/github/keeganwitt/applist/SharedPreferencesAppSettingsTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/SharedPreferencesAppSettingsTest.kt
@@ -83,4 +83,43 @@ class SharedPreferencesAppSettingsTest {
         val field = appSettings.getLastDisplayedAppInfoField()
         assertTrue(field == AppInfoField.VERSION)
     }
+
+    @Test
+    fun `getLastDisplayedAppInfoField returns VERSION when value is empty`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager
+            .getDefaultSharedPreferences(context)
+            .edit()
+            .putString(AppSettings.KEY_LAST_DISPLAYED_APP_INFO_FIELD, "")
+            .commit()
+
+        val field = appSettings.getLastDisplayedAppInfoField()
+        assertTrue(field == AppInfoField.VERSION)
+    }
+
+    @Test
+    fun `getThemeMode returns SYSTEM when value is invalid`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager
+            .getDefaultSharedPreferences(context)
+            .edit()
+            .putString(AppSettings.KEY_THEME_MODE, "INVALID_VALUE")
+            .commit()
+
+        val mode = appSettings.getThemeMode()
+        assertTrue(mode == AppSettings.ThemeMode.SYSTEM)
+    }
+
+    @Test
+    fun `getThemeMode returns SYSTEM when value is empty`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager
+            .getDefaultSharedPreferences(context)
+            .edit()
+            .putString(AppSettings.KEY_THEME_MODE, "")
+            .commit()
+
+        val mode = appSettings.getThemeMode()
+        assertTrue(mode == AppSettings.ThemeMode.SYSTEM)
+    }
 }


### PR DESCRIPTION
This PR improves the test coverage for `SharedPreferencesAppSettings`.

**Changes:**
- Added a test case `getLastDisplayedAppInfoField returns VERSION when value is empty` to explicitely cover empty string handling.
- Added a test case `getThemeMode returns SYSTEM when value is invalid` to cover invalid enum value handling for theme mode.
- Added a test case `getThemeMode returns SYSTEM when value is empty` to cover empty string handling for theme mode.

**Verification:**
- Verified that all unit tests pass with `./gradlew testDebugUnitTest`.
- Confirmed that the existing test `getLastDisplayedAppInfoField returns VERSION when value is invalid` was already present and passing.


---
*PR created automatically by Jules for task [12146712732765276650](https://jules.google.com/task/12146712732765276650) started by @keeganwitt*