### PR TITLE
Refactor usage stats permission check into AppInfoField

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppInfoField.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppInfoField.kt
@@ -5,6 +5,7 @@ import java.util.Date
 
 enum class AppInfoField(
     val titleResId: Int,
+    val requiresUsageStats: Boolean = false,
 ) {
     APK_SIZE(R.string.appInfoField_apkSize) {
         override fun getValue(app: App) = app.sizes.apkBytes
@@ -16,10 +17,10 @@ enum class AppInfoField(
         override fun getValue(app: App) = app.archived ?: false
         override fun getFormattedValue(app: App) = (app.archived ?: false).toString()
     },
-    CACHE_SIZE(R.string.appInfoField_cacheSize) {
+    CACHE_SIZE(R.string.appInfoField_cacheSize, requiresUsageStats = true) {
         override fun getValue(app: App) = app.sizes.cacheBytes
     },
-    DATA_SIZE(R.string.appInfoField_dataSize) {
+    DATA_SIZE(R.string.appInfoField_dataSize, requiresUsageStats = true) {
         override fun getValue(app: App) = app.sizes.dataBytes
     },
     ENABLED(R.string.appInfoField_enabled) {
@@ -30,7 +31,7 @@ enum class AppInfoField(
         override fun getValue(app: App) = app.existsInStore ?: false
         override fun getFormattedValue(app: App) = (app.existsInStore ?: false).toString()
     },
-    EXTERNAL_CACHE_SIZE(R.string.appInfoField_externalCacheSize) {
+    EXTERNAL_CACHE_SIZE(R.string.appInfoField_externalCacheSize, requiresUsageStats = true) {
         override fun getValue(app: App) = app.sizes.externalCacheBytes
     },
     FIRST_INSTALLED(R.string.appInfoField_firstInstalled) {
@@ -46,7 +47,7 @@ enum class AppInfoField(
         override fun getFormattedValue(app: App) =
             app.lastUpdated?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
     },
-    LAST_USED(R.string.appInfoField_lastUsed) {
+    LAST_USED(R.string.appInfoField_lastUsed, requiresUsageStats = true) {
         override fun getValue(app: App) = app.lastUsed
         override fun getFormattedValue(app: App) =
             app.lastUsed?.let { DateFormat.getDateTimeInstance().format(Date(it)) } ?: ""
@@ -65,7 +66,7 @@ enum class AppInfoField(
         override fun getValue(app: App) = app.targetSdk ?: 0
         override fun getFormattedValue(app: App) = app.targetSdk?.toString() ?: ""
     },
-    TOTAL_SIZE(R.string.appInfoField_totalSize) {
+    TOTAL_SIZE(R.string.appInfoField_totalSize, requiresUsageStats = true) {
         override fun getValue(app: App) = app.sizes.totalBytes
     },
     VERSION(R.string.appInfoField_version) {

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -255,14 +255,7 @@ class MainActivity :
     }
 
     private fun maybeRequestUsagePermission(field: AppInfoField) {
-        if ((
-                field == AppInfoField.CACHE_SIZE ||
-                    field == AppInfoField.DATA_SIZE ||
-                    field == AppInfoField.EXTERNAL_CACHE_SIZE ||
-                    field == AppInfoField.TOTAL_SIZE ||
-                    field == AppInfoField.LAST_USED
-            ) && !hasUsageStatsPermission()
-        ) {
+        if (field.requiresUsageStats && !hasUsageStatsPermission()) {
             requestUsageStatsPermission()
         }
     }

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppInfoFieldTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppInfoFieldTest.kt
@@ -304,4 +304,30 @@ class AppInfoFieldTest {
         assertEquals("0", AppInfoField.GRANTED_PERMISSIONS.getFormattedValue(app))
         assertEquals("0", AppInfoField.REQUESTED_PERMISSIONS.getFormattedValue(app))
     }
+
+    @Test
+    fun `given field requiring usage stats, when accessed, then requiresUsageStats is true`() {
+        assertEquals(true, AppInfoField.CACHE_SIZE.requiresUsageStats)
+        assertEquals(true, AppInfoField.DATA_SIZE.requiresUsageStats)
+        assertEquals(true, AppInfoField.EXTERNAL_CACHE_SIZE.requiresUsageStats)
+        assertEquals(true, AppInfoField.TOTAL_SIZE.requiresUsageStats)
+        assertEquals(true, AppInfoField.LAST_USED.requiresUsageStats)
+    }
+
+    @Test
+    fun `given field not requiring usage stats, when accessed, then requiresUsageStats is false`() {
+        assertEquals(false, AppInfoField.APK_SIZE.requiresUsageStats)
+        assertEquals(false, AppInfoField.APP_SIZE.requiresUsageStats)
+        assertEquals(false, AppInfoField.ARCHIVED.requiresUsageStats)
+        assertEquals(false, AppInfoField.ENABLED.requiresUsageStats)
+        assertEquals(false, AppInfoField.EXISTS_IN_APP_STORE.requiresUsageStats)
+        assertEquals(false, AppInfoField.FIRST_INSTALLED.requiresUsageStats)
+        assertEquals(false, AppInfoField.GRANTED_PERMISSIONS.requiresUsageStats)
+        assertEquals(false, AppInfoField.LAST_UPDATED.requiresUsageStats)
+        assertEquals(false, AppInfoField.MIN_SDK.requiresUsageStats)
+        assertEquals(false, AppInfoField.PACKAGE_MANAGER.requiresUsageStats)
+        assertEquals(false, AppInfoField.REQUESTED_PERMISSIONS.requiresUsageStats)
+        assertEquals(false, AppInfoField.TARGET_SDK.requiresUsageStats)
+        assertEquals(false, AppInfoField.VERSION.requiresUsageStats)
+    }
 }


### PR DESCRIPTION
Refactor usage stats permission check into AppInfoField

Moved the logic for determining which fields require usage stats permission from `MainActivity` to the `AppInfoField` enum. This improves encapsulation and reduces the risk of future errors if new fields are added.

- Added `requiresUsageStats` property to `AppInfoField`.
- Updated `MainActivity` to use `field.requiresUsageStats`.
- Added unit tests to `AppInfoFieldTest`.

---
*PR created automatically by Jules for task [11040355727538382213](https://jules.google.com/task/11040355727538382213) started by @keeganwitt*