### PR TITLE
Refactor theme mode logic to reduce duplication

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListApplication.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListApplication.kt
@@ -6,6 +6,7 @@ import coil.ImageLoaderFactory
 import com.github.keeganwitt.applist.services.AndroidPackageService
 import com.github.keeganwitt.applist.utils.PackageIconFetcher
 import com.github.keeganwitt.applist.utils.PackageIconKeyer
+import com.github.keeganwitt.applist.utils.nightMode
 
 open class AppListApplication : Application(), ImageLoaderFactory {
     override fun onCreate() {
@@ -18,22 +19,8 @@ open class AppListApplication : Application(), ImageLoaderFactory {
         }
 
         val themeMode = appSettings.getThemeMode()
-        val nightMode =
-            when (themeMode) {
-                AppSettings.ThemeMode.LIGHT -> {
-                    androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
-                }
-
-                AppSettings.ThemeMode.DARK -> {
-                    androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
-                }
-
-                AppSettings.ThemeMode.SYSTEM -> {
-                    androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                }
-            }
         androidx.appcompat.app.AppCompatDelegate
-            .setDefaultNightMode(nightMode)
+            .setDefaultNightMode(themeMode.nightMode)
     }
 
     override fun newImageLoader(): ImageLoader {

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -29,6 +29,7 @@ import com.github.keeganwitt.applist.services.AndroidPackageService
 import com.github.keeganwitt.applist.services.AndroidStorageService
 import com.github.keeganwitt.applist.services.AndroidUsageStatsService
 import com.github.keeganwitt.applist.services.PlayStoreService
+import com.github.keeganwitt.applist.utils.nightMode
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.text.Collator
@@ -64,22 +65,8 @@ class MainActivity :
         appSettings = SharedPreferencesAppSettings(this)
 
         val themeMode = appSettings.getThemeMode()
-        val nightMode =
-            when (themeMode) {
-                AppSettings.ThemeMode.LIGHT -> {
-                    androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
-                }
-
-                AppSettings.ThemeMode.DARK -> {
-                    androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
-                }
-
-                AppSettings.ThemeMode.SYSTEM -> {
-                    androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                }
-            }
         androidx.appcompat.app.AppCompatDelegate
-            .setDefaultNightMode(nightMode)
+            .setDefaultNightMode(themeMode.nightMode)
 
         appAdapter = AppAdapter(this)
         binding.recyclerView.layoutManager = GridAutofitLayoutManager(this, 450)

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/SettingsActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
 import com.github.keeganwitt.applist.databinding.ActivitySettingsBinding
+import com.github.keeganwitt.applist.utils.nightMode
 
 class SettingsActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySettingsBinding
@@ -56,23 +57,8 @@ class SettingsActivity : AppCompatActivity() {
             findPreference<androidx.preference.ListPreference>(AppSettings.KEY_THEME_MODE)
                 ?.setOnPreferenceChangeListener { _, newValue ->
                     val mode = AppSettings.ThemeMode.valueOf(newValue as String)
-                    val nightMode =
-                        when (mode) {
-                            AppSettings.ThemeMode.LIGHT -> {
-                                androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
-                            }
-
-                            AppSettings.ThemeMode.DARK -> {
-                                androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
-                            }
-
-                            AppSettings.ThemeMode.SYSTEM -> {
-                                androidx.appcompat.app.AppCompatDelegate
-                                    .MODE_NIGHT_FOLLOW_SYSTEM
-                            }
-                        }
                     androidx.appcompat.app.AppCompatDelegate
-                        .setDefaultNightMode(nightMode)
+                        .setDefaultNightMode(mode.nightMode)
                     true
                 }
         }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/utils/ThemeModeExtensions.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/utils/ThemeModeExtensions.kt
@@ -1,0 +1,15 @@
+package com.github.keeganwitt.applist.utils
+
+import androidx.appcompat.app.AppCompatDelegate
+import com.github.keeganwitt.applist.AppSettings
+
+/**
+ * Maps the [AppSettings.ThemeMode] to the corresponding [AppCompatDelegate] night mode constant.
+ */
+val AppSettings.ThemeMode.nightMode: Int
+    get() =
+        when (this) {
+            AppSettings.ThemeMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+            AppSettings.ThemeMode.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+            AppSettings.ThemeMode.SYSTEM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/utils/ThemeModeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/utils/ThemeModeExtensionsTest.kt
@@ -1,0 +1,24 @@
+package com.github.keeganwitt.applist.utils
+
+import androidx.appcompat.app.AppCompatDelegate
+import com.github.keeganwitt.applist.AppSettings
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThemeModeExtensionsTest {
+
+    @Test
+    fun `nightMode returns MODE_NIGHT_NO for LIGHT theme`() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_NO, AppSettings.ThemeMode.LIGHT.nightMode)
+    }
+
+    @Test
+    fun `nightMode returns MODE_NIGHT_YES for DARK theme`() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_YES, AppSettings.ThemeMode.DARK.nightMode)
+    }
+
+    @Test
+    fun `nightMode returns MODE_NIGHT_FOLLOW_SYSTEM for SYSTEM theme`() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, AppSettings.ThemeMode.SYSTEM.nightMode)
+    }
+}


### PR DESCRIPTION
Refactored theme mode logic to reduce duplication

-   **What:** Extracted the logic for mapping `AppSettings.ThemeMode` to `AppCompatDelegate` night mode constants into a reusable extension property `nightMode` in `ThemeModeExtensions.kt`.
-   **Why:** The same `when` expression was duplicated in `AppListApplication`, `MainActivity`, and `SettingsActivity`. This refactoring improves maintainability by centralizing the logic.
-   **Verification:** Added `ThemeModeExtensionsTest` to verify the mapping correctness. Ran `AppListApplicationTest` to ensure no regressions in theme application.
-   **Result:** Cleaner code with centralized theme mode logic.

---
*PR created automatically by Jules for task [16247844714070417492](https://jules.google.com/task/16247844714070417492) started by @keeganwitt*