### PR TITLE
🧹 Refactor UsageStatsService to use java.time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+        isCoreLibraryDesugaringEnabled = true
     }
 
     testOptions {
@@ -59,6 +60,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.2")
+
     // Android dependencies
     implementation("androidx.activity:activity-ktx:1.12.4")
     implementation("androidx.appcompat:appcompat:1.7.1")

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/services/UsageStatsService.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/services/UsageStatsService.kt
@@ -3,7 +3,8 @@ package com.github.keeganwitt.applist.services
 import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
 import android.content.Context
-import java.util.Calendar
+import java.time.Clock
+import java.time.ZonedDateTime
 
 interface UsageStatsService {
     fun getLastUsedEpochs(reload: Boolean): Map<String, Long>
@@ -12,16 +13,16 @@ interface UsageStatsService {
 class AndroidUsageStatsService(
     context: Context,
     usageStatsManager: UsageStatsManager? = null,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) : UsageStatsService {
     private val actualUsageStatsManager = usageStatsManager ?: (context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager)
     private var cache: Map<String, Long>? = null
 
     override fun getLastUsedEpochs(reload: Boolean): Map<String, Long> {
         if (cache == null || reload) {
-            val calendar = Calendar.getInstance()
-            val end = calendar.timeInMillis
-            calendar.add(Calendar.YEAR, -2)
-            val start = calendar.timeInMillis
+            val now = ZonedDateTime.now(clock)
+            val end = now.toInstant().toEpochMilli()
+            val start = now.minusYears(2).toInstant().toEpochMilli()
             val aggregated: Map<String, UsageStats> = actualUsageStatsManager.queryAndAggregateUsageStats(start, end)
             cache = aggregated.mapValues { it.value.lastTimeUsed }
         }

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/services/UsageStatsServiceTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/services/UsageStatsServiceTest.kt
@@ -10,17 +10,38 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 class UsageStatsServiceTest {
     private lateinit var context: Context
     private lateinit var usageStatsManager: UsageStatsManager
     private lateinit var service: AndroidUsageStatsService
+    private lateinit var clock: Clock
 
     @Before
     fun setup() {
         context = mockk(relaxed = true)
         usageStatsManager = mockk(relaxed = true)
-        service = AndroidUsageStatsService(context, usageStatsManager)
+        // Fixed time: 2023-01-01 12:00:00 UTC
+        val fixedInstant = Instant.parse("2023-01-01T12:00:00Z")
+        clock = Clock.fixed(fixedInstant, ZoneId.of("UTC"))
+        service = AndroidUsageStatsService(context, usageStatsManager, clock)
+    }
+
+    @Test
+    fun `given fixed clock, when getLastUsedEpochs called, then queries with correct timestamps`() {
+        every { usageStatsManager.queryAndAggregateUsageStats(any(), any()) } returns emptyMap()
+
+        service.getLastUsedEpochs(reload = false)
+
+        // 2023-01-01 12:00:00 UTC
+        val expectedEnd = Instant.parse("2023-01-01T12:00:00Z").toEpochMilli()
+        // 2021-01-01 12:00:00 UTC
+        val expectedStart = Instant.parse("2021-01-01T12:00:00Z").toEpochMilli()
+
+        verify { usageStatsManager.queryAndAggregateUsageStats(expectedStart, expectedEnd) }
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** Replaced legacy `java.util.Calendar` usage with `java.time` APIs in `UsageStatsService.kt`.

💡 **Why:** `java.util.Calendar` is legacy and error-prone. `java.time` is the modern standard, offering better immutability, thread-safety, and clarity. This improves code health and maintainability.

✅ **Verification:**
- Added `Clock` injection to `AndroidUsageStatsService` to enable deterministic testing.
- Updated `UsageStatsServiceTest` to use a fixed `Clock` and verify correct timestamp calculation.
- Enabled `coreLibraryDesugaring` in `app/build.gradle.kts` to support `java.time` on API 24+.
- Verified tests pass with `./gradlew :app:testDebugUnitTest`.
- Verified lint passes with `./gradlew :app:lintDebug`.

✨ **Result:** Code is cleaner, testable, and uses modern date/time APIs.

---
*PR created automatically by Jules for task [8990080188297344686](https://jules.google.com/task/8990080188297344686) started by @keeganwitt*