### PR TITLE
🧪 [AppListApplication: Untested newImageLoader Configuration]

### DIFF
--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListApplicationTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListApplicationTest.kt
@@ -5,6 +5,8 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.keeganwitt.applist.utils.PackageIconFetcher
+import com.github.keeganwitt.applist.utils.PackageIconKeyer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -135,5 +137,22 @@ class AppListApplicationTest {
         application.onCreate()
 
         assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, AppCompatDelegate.getDefaultNightMode())
+    }
+
+    @Test
+    fun `when newImageLoader called then it contains expected components`() {
+        val application =
+            object : AppListApplication() {
+                init {
+                    attachBaseContext(context)
+                }
+            }
+        val imageLoader = application.newImageLoader()
+
+        val fetcherFactories = imageLoader.components.fetcherFactories
+        assertTrue(fetcherFactories.any { it.first is PackageIconFetcher.Factory })
+
+        val keyers = imageLoader.components.keyers
+        assertTrue(keyers.any { it.first is PackageIconKeyer })
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for `newImageLoader` configuration in `AppListApplication` has been addressed.
📊 **Coverage:** A new test case has been added to `AppListApplicationTest` to verify that the `ImageLoader` returned by `newImageLoader()` contains the expected custom components (`PackageIconFetcher.Factory` and `PackageIconKeyer`).
✨ **Result:** Improved test coverage for `AppListApplication` and ensured that the icon loading configuration is correctly set up.

---
*PR created automatically by Jules for task [9787028483405042932](https://jules.google.com/task/9787028483405042932) started by @keeganwitt*