### PR TITLE
🧹 Refactor AppAdapter to use View Binding

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppAdapter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppAdapter.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.github.keeganwitt.applist.AppAdapter.AppInfoViewHolder
+import com.github.keeganwitt.applist.databinding.SnippetListRowBinding
 import com.github.keeganwitt.applist.utils.PackageIcon
 
 class AppAdapter(
@@ -24,8 +25,8 @@ class AppAdapter(
         viewType: Int,
     ): AppInfoViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val view = inflater.inflate(R.layout.snippet_list_row, parent, false)
-        return AppInfoViewHolder(view)
+        val binding = SnippetListRowBinding.inflate(inflater, parent, false)
+        return AppInfoViewHolder(binding)
     }
 
     override fun onBindViewHolder(
@@ -33,21 +34,18 @@ class AppAdapter(
         position: Int,
     ) {
         val item = currentList[position]
-        val iconView = holder.iconView
-        val appNameView = holder.appNameView
-        val appInfoView = holder.appInfoView
-        val packageNameView = holder.packageNameView
+        val binding = holder.binding
 
-        iconView.load(PackageIcon(item.packageName)) {
+        binding.appIcon.load(PackageIcon(item.packageName)) {
             placeholder(android.R.drawable.sym_def_app_icon)
             error(android.R.drawable.sym_def_app_icon)
             fallback(android.R.drawable.sym_def_app_icon)
         }
 
-        packageNameView.text = item.packageName
-        appNameView.text = item.appName
-        appInfoView.movementMethod = LinkMovementMethod.getInstance()
-        appInfoView.text = item.infoText
+        binding.packageName.text = item.packageName
+        binding.appName.text = item.appName
+        binding.appInfo.movementMethod = LinkMovementMethod.getInstance()
+        binding.appInfo.text = item.infoText
     }
 
     interface OnClickListener {
@@ -55,16 +53,11 @@ class AppAdapter(
     }
 
     inner class AppInfoViewHolder(
-        itemView: View,
-    ) : RecyclerView.ViewHolder(itemView),
+        val binding: SnippetListRowBinding,
+    ) : RecyclerView.ViewHolder(binding.root),
         View.OnClickListener {
-        var iconView: ImageView = itemView.findViewById(R.id.app_icon)
-        var appNameView: TextView = itemView.findViewById(R.id.app_name)
-        var packageNameView: TextView = itemView.findViewById(R.id.package_name)
-        var appInfoView: TextView = itemView.findViewById(R.id.app_info)
-
         init {
-            itemView.setOnClickListener(this)
+            binding.root.setOnClickListener(this)
         }
 
         override fun onClick(v: View?) {


### PR DESCRIPTION
This PR refactors `AppAdapter` to use **View Binding** instead of manual `findViewById` calls in `AppInfoViewHolder`.

### 🎯 What:
- Migrated `AppInfoViewHolder` to use `SnippetListRowBinding`.
- Removed manual view lookup properties in `AppInfoViewHolder`.
- Updated `onCreateViewHolder` to use `SnippetListRowBinding.inflate`.
- Updated `onBindViewHolder` to access views via the binding object.

### 💡 Why:
- Improves code readability and maintainability.
- Provides compile-time type safety for view access.
- Follows modern Android development best practices already used elsewhere in the project.

### ✅ Verification:
- Ran `AppAdapterTest` unit tests, which passed.
- Verified successful project compilation with `./gradlew assembleDebug`.

### ✨ Result:
- Cleaner and safer code in `AppAdapter.kt`.

---
*PR created automatically by Jules for task [11170640024091788061](https://jules.google.com/task/11170640024091788061) started by @keeganwitt*