### PR TITLE
Add CSV and TSV export options (#72)

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
@@ -52,6 +52,14 @@ class AppExporter(
                             writeHtmlToFile(uri)
                         }
 
+                        ExportFormat.CSV -> {
+                            writeCsvToFile(uri)
+                        }
+
+                        ExportFormat.TSV -> {
+                            writeTsvToFile(uri)
+                        }
+
                         null -> { /* Should not happen */ }
                     }
                 }
@@ -79,6 +87,10 @@ class AppExporter(
                 initiateExport(ExportFormat.XML)
             } else if (selectedId == R.id.radio_html) {
                 initiateExport(ExportFormat.HTML)
+            } else if (selectedId == R.id.radio_csv) {
+                initiateExport(ExportFormat.CSV)
+            } else if (selectedId == R.id.radio_tsv) {
+                initiateExport(ExportFormat.TSV)
             }
         }
         builder.setNegativeButton(
@@ -122,6 +134,26 @@ class AppExporter(
         activity.lifecycleScope.launch(dispatchers.io) {
             exportToFile(uri, ExportFormat.XML, items) {
                 formatter.toXml(it, field)
+            }
+        }
+    }
+
+    internal fun writeCsvToFile(uri: Uri) {
+        val items = itemsProvider()
+        val field = selectedAppInfoField!!
+        activity.lifecycleScope.launch(dispatchers.io) {
+            exportToFile(uri, ExportFormat.CSV, items) {
+                formatter.toCsv(it, field)
+            }
+        }
+    }
+
+    internal fun writeTsvToFile(uri: Uri) {
+        val items = itemsProvider()
+        val field = selectedAppInfoField!!
+        activity.lifecycleScope.launch(dispatchers.io) {
+            exportToFile(uri, ExportFormat.TSV, items) {
+                formatter.toTsv(it, field)
             }
         }
     }
@@ -194,5 +226,7 @@ class AppExporter(
     ) {
         XML("xml", "text/xml", "XML"),
         HTML("html", "text/html", "HTML"),
+        CSV("csv", "text/csv", "CSV"),
+        TSV("tsv", "text/tab-separated-values", "TSV"),
     }
 }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/ExportFormatter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/ExportFormatter.kt
@@ -58,6 +58,36 @@ class ExportFormatter {
         return sb.toString()
     }
 
+    fun toCsv(
+        items: List<AppItemUiModel>,
+        selectedField: AppInfoField,
+    ): String {
+        val sb = StringBuilder()
+        sb.append("App Name,Package Name,Info Type,Info Value\n")
+        items.forEach { item ->
+            sb.append("\"").append(item.appName.replace("\"", "\"\"")).append("\",")
+            sb.append("\"").append(item.packageName.replace("\"", "\"\"")).append("\",")
+            sb.append("\"").append(selectedField.name.replace("\"", "\"\"")).append("\",")
+            sb.append("\"").append(item.infoText.replace("\"", "\"\"")).append("\"\n")
+        }
+        return sb.toString()
+    }
+
+    fun toTsv(
+        items: List<AppItemUiModel>,
+        selectedField: AppInfoField,
+    ): String {
+        val sb = StringBuilder()
+        sb.append("App Name\tPackage Name\tInfo Type\tInfo Value\n")
+        items.forEach { item ->
+            sb.append(item.appName).append("\t")
+            sb.append(item.packageName).append("\t")
+            sb.append(selectedField.name).append("\t")
+            sb.append(item.infoText).append("\n")
+        }
+        return sb.toString()
+    }
+
     // This is not using Html.escapeHtml for unit tests (since it's not implemented by Robolectric)
     private fun escapeMarkup(s: String): String =
         s

--- a/app/src/main/res/layout/dialog_export_type.xml
+++ b/app/src/main/res/layout/dialog_export_type.xml
@@ -29,6 +29,18 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/export_html" />
+
+        <RadioButton
+            android:id="@+id/radio_csv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/export_csv" />
+
+        <RadioButton
+            android:id="@+id/radio_tsv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/export_tsv" />
     </RadioGroup>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
   <string name="export_as">Export as</string>
   <string name="export_xml" translatable="false">XML</string>
   <string name="export_html" translatable="false">HTML</string>
+  <string name="export_csv" translatable="false">CSV</string>
+  <string name="export_tsv" translatable="false">TSV</string>
   <string name="export_no_apps">No apps to export</string>
   <string name="export_successful">Export successful</string>
   <string name="export_failed">Export failed: %1$s</string>

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppExporterTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppExporterTest.kt
@@ -205,4 +205,42 @@ class AppExporterTest {
         val expected = activity.getString(R.string.export_failed, "Failed to open output stream")
         assertTrue(toast.toString() == expected)
     }
+
+    @Test
+    fun writeCsvToFile_writesContent_andShowsSuccessToast() {
+        val formatter = mockk<ExportFormatter>()
+        val csvOutput = "App Name,Package Name,Info Type,Info Value\n\"App 1\",\"com.example.app1\",\"VERSION\",\"1.0\""
+        every { formatter.toCsv(any(), any()) } returns csvOutput
+
+        val exporter = AppExporter(activity, { items }, formatter, crashReporter, testDispatchers)
+        exporter.selectedAppInfoField = AppInfoField.VERSION
+        val file = File.createTempFile("apps", ".csv").apply { deleteOnExit() }
+        val uri = Uri.fromFile(file)
+
+        exporter.writeCsvToFile(uri)
+        Shadows.shadowOf(activity.mainLooper).idle()
+
+        verify { formatter.toCsv(items, AppInfoField.VERSION) }
+        val toast = ShadowToast.getTextOfLatestToast()
+        assertTrue(toast.toString() == activity.getString(R.string.export_successful))
+    }
+
+    @Test
+    fun writeTsvToFile_writesContent_andShowsSuccessToast() {
+        val formatter = mockk<ExportFormatter>()
+        val tsvOutput = "App Name\tPackage Name\tInfo Type\tInfo Value\nApp 1\tcom.example.app1\tVERSION\t1.0"
+        every { formatter.toTsv(any(), any()) } returns tsvOutput
+
+        val exporter = AppExporter(activity, { items }, formatter, crashReporter, testDispatchers)
+        exporter.selectedAppInfoField = AppInfoField.VERSION
+        val file = File.createTempFile("apps", ".tsv").apply { deleteOnExit() }
+        val uri = Uri.fromFile(file)
+
+        exporter.writeTsvToFile(uri)
+        Shadows.shadowOf(activity.mainLooper).idle()
+
+        verify { formatter.toTsv(items, AppInfoField.VERSION) }
+        val toast = ShadowToast.getTextOfLatestToast()
+        assertTrue(toast.toString() == activity.getString(R.string.export_successful))
+    }
 }

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/ExportFormatterTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/ExportFormatterTest.kt
@@ -230,4 +230,82 @@ class ExportFormatterTest {
                 "</html>\n"
         assertEquals(expected, result)
     }
+
+    @Test
+    fun `given list of apps, when toCsv called, then return correct csv`() {
+        // Given
+        val items =
+            listOf(
+                AppItemUiModel(
+                    packageName = "com.example.app1",
+                    appName = "App 1",
+                    infoText = "1.0",
+                ),
+                AppItemUiModel(
+                    packageName = "com.example.app2",
+                    appName = "App 2",
+                    infoText = "2.0",
+                ),
+            )
+
+        // When
+        val result = formatter.toCsv(items, AppInfoField.VERSION)
+
+        // Then
+        val expected =
+            "App Name,Package Name,Info Type,Info Value\n" +
+                "\"App 1\",\"com.example.app1\",\"VERSION\",\"1.0\"\n" +
+                "\"App 2\",\"com.example.app2\",\"VERSION\",\"2.0\"\n"
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given apps with quotes and commas, when toCsv called, then return escaped csv`() {
+        // Given
+        val items =
+            listOf(
+                AppItemUiModel(
+                    packageName = "com.example.app,1",
+                    appName = "App \"1\"",
+                    infoText = "1.0",
+                ),
+            )
+
+        // When
+        val result = formatter.toCsv(items, AppInfoField.VERSION)
+
+        // Then
+        val expected =
+            "App Name,Package Name,Info Type,Info Value\n" +
+                "\"App \"\"1\"\"\",\"com.example.app,1\",\"VERSION\",\"1.0\"\n"
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given list of apps, when toTsv called, then return correct tsv`() {
+        // Given
+        val items =
+            listOf(
+                AppItemUiModel(
+                    packageName = "com.example.app1",
+                    appName = "App 1",
+                    infoText = "1.0",
+                ),
+                AppItemUiModel(
+                    packageName = "com.example.app2",
+                    appName = "App 2",
+                    infoText = "2.0",
+                ),
+            )
+
+        // When
+        val result = formatter.toTsv(items, AppInfoField.VERSION)
+
+        // Then
+        val expected =
+            "App Name\tPackage Name\tInfo Type\tInfo Value\n" +
+                "App 1\tcom.example.app1\tVERSION\t1.0\n" +
+                "App 2\tcom.example.app2\tVERSION\t2.0\n"
+        assertEquals(expected, result)
+    }
 }


### PR DESCRIPTION
This change adds CSV and TSV export options to the app. Both formats include a header: "App Name, Package Name, Info Type, Info Value". CSV is properly formatted according to RFC 4180 (quoting fields and escaping existing quotes). TSV uses tab separation. Unit tests were added to ensure the formatting and export logic are correct.

---
*PR created automatically by Jules for task [15958807614319497391](https://jules.google.com/task/15958807614319497391) started by @keeganwitt*