### PR TITLE
🧪 Add test for AppListViewModel filtering by infoText

### DIFF
--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -306,6 +306,28 @@ class AppListViewModelTest {
             coVerify { summaryCalculator.calculate(listOf(app1), AppInfoField.ENABLED) }
         }
 
+    @Test
+    fun `given apps loaded, when query matches info text, then app is included in filtered results`() =
+        runTest {
+            val mockApps =
+                listOf(
+                    createTestApp("com.test.app1", "App One", versionName = "1.2.3"),
+                    createTestApp("com.test.app2", "App Two", versionName = "2.0.0"),
+                )
+            coEvery { repository.loadApps(any(), any(), any(), any()) } returns flowOf(mockApps)
+
+            viewModel.init(AppInfoField.VERSION)
+            advanceUntilIdle()
+
+            viewModel.setQuery("1.2.3")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(1, state.items.size)
+            assertEquals("com.test.app1", state.items[0].packageName)
+            assertEquals("1.2.3", state.items[0].infoText)
+        }
+
     private fun createTestApp(
         packageName: String,
         name: String,


### PR DESCRIPTION
This PR adds a missing unit test for the filtering logic in `AppListViewModel`. Specifically, it verifies that searching by the `infoText` field (which can contain version names, SDK levels, etc., depending on the selected field) works as expected.

### 🎯 What: The testing gap addressed
The `AppListViewModel` filtering logic included `item.infoText.contains(state.query, ignoreCase = true)`, but there was no test case explicitly covering this condition.

### 📊 Coverage: What scenarios are now tested
A new test case `given apps loaded, when query matches info text, then app is included in filtered results` was added to `AppListViewModelTest.kt`. This test mocks apps with different version names and verifies that searching for a specific version name correctly filters the list.

### ✨ Result: The improvement in test coverage
The filtering logic in `AppListViewModel` is now more thoroughly tested, ensuring that search functionality remains robust as new fields or formatting logic are added.

---
*PR created automatically by Jules for task [14249694160100571374](https://jules.google.com/task/14249694160100571374) started by @keeganwitt*