### PR TITLE
🧹 Replace deprecated PreferenceManager.getDefaultSharedPreferences usage

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppSettings.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppSettings.kt
@@ -3,7 +3,6 @@ package com.github.keeganwitt.applist
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.preference.PreferenceManager
 
 interface AppSettings {
     fun isCrashReportingEnabled(): Boolean
@@ -28,6 +27,7 @@ interface AppSettings {
         const val KEY_CRASH_REPORTING_ENABLED = "crash_reporting_enabled"
         const val KEY_LAST_DISPLAYED_APP_INFO_FIELD = "last_displayed_app_info_field"
         const val KEY_THEME_MODE = "theme_mode"
+        const val DEFAULT_PREF_NAME_SUFFIX = "_preferences"
     }
 }
 
@@ -35,7 +35,10 @@ class SharedPreferencesAppSettings(
     context: Context,
 ) : AppSettings {
     private val preferences: SharedPreferences =
-        PreferenceManager.getDefaultSharedPreferences(context)
+        context.getSharedPreferences(
+            context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX,
+            Context.MODE_PRIVATE,
+        )
 
     override fun isCrashReportingEnabled(): Boolean = preferences.getBoolean(AppSettings.KEY_CRASH_REPORTING_ENABLED, true)
 

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListApplicationTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListApplicationTest.kt
@@ -2,7 +2,6 @@ package com.github.keeganwitt.applist
 
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.keeganwitt.applist.utils.PackageIconFetcher
@@ -22,8 +21,8 @@ class AppListApplicationTest {
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        PreferenceManager
-            .getDefaultSharedPreferences(context)
+        context
+            .getSharedPreferences(context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .commit()

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/SharedPreferencesAppSettingsTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/SharedPreferencesAppSettingsTest.kt
@@ -1,7 +1,6 @@
 package com.github.keeganwitt.applist
 
 import android.content.Context
-import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertFalse
@@ -19,8 +18,8 @@ class SharedPreferencesAppSettingsTest {
     @Before
     fun `set up`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        PreferenceManager
-            .getDefaultSharedPreferences(context)
+        context
+            .getSharedPreferences(context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX, Context.MODE_PRIVATE)
             .edit()
             .clear()
             .commit()
@@ -74,8 +73,8 @@ class SharedPreferencesAppSettingsTest {
     @Test
     fun `getLastDisplayedAppInfoField returns VERSION when value is invalid`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        PreferenceManager
-            .getDefaultSharedPreferences(context)
+        context
+            .getSharedPreferences(context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX, Context.MODE_PRIVATE)
             .edit()
             .putString(AppSettings.KEY_LAST_DISPLAYED_APP_INFO_FIELD, "INVALID_VALUE")
             .commit()
@@ -87,8 +86,8 @@ class SharedPreferencesAppSettingsTest {
     @Test
     fun `getLastDisplayedAppInfoField returns VERSION when value is empty`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        PreferenceManager
-            .getDefaultSharedPreferences(context)
+        context
+            .getSharedPreferences(context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX, Context.MODE_PRIVATE)
             .edit()
             .putString(AppSettings.KEY_LAST_DISPLAYED_APP_INFO_FIELD, "")
             .commit()
@@ -100,8 +99,8 @@ class SharedPreferencesAppSettingsTest {
     @Test
     fun `getThemeMode returns SYSTEM when value is invalid`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        PreferenceManager
-            .getDefaultSharedPreferences(context)
+        context
+            .getSharedPreferences(context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX, Context.MODE_PRIVATE)
             .edit()
             .putString(AppSettings.KEY_THEME_MODE, "INVALID_VALUE")
             .commit()
@@ -113,8 +112,8 @@ class SharedPreferencesAppSettingsTest {
     @Test
     fun `getThemeMode returns SYSTEM when value is empty`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        PreferenceManager
-            .getDefaultSharedPreferences(context)
+        context
+            .getSharedPreferences(context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX, Context.MODE_PRIVATE)
             .edit()
             .putString(AppSettings.KEY_THEME_MODE, "")
             .commit()


### PR DESCRIPTION
This change addresses the code health issue regarding the deprecated `PreferenceManager.getDefaultSharedPreferences` usage.

Key changes:
- Defined `AppSettings.DEFAULT_PREF_NAME_SUFFIX` as `"_preferences"`.
- Updated `SharedPreferencesAppSettings` to use `context.getSharedPreferences(context.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX, Context.MODE_PRIVATE)`.
- Updated test files `SharedPreferencesAppSettingsTest.kt` and `AppListApplicationTest.kt` to follow the same pattern.
- Removed the `androidx.preference.PreferenceManager` import where it was no longer needed.
- Verified that the functionality remains unchanged and all tests pass.

---
*PR created automatically by Jules for task [1432861887835499663](https://jules.google.com/task/1432861887835499663) started by @keeganwitt*