### PR TITLE
🧹 Refactor GridAutofitLayoutManager constructor logic

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/GridAutofitLayoutManager.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/GridAutofitLayoutManager.kt
@@ -14,24 +14,23 @@ class GridAutofitLayoutManager : GridLayoutManager {
     private var lastHeight = 0
 
     constructor(context: Context, columnWidth: Int) : super(context, 1) {
-        setColumnWidth(checkedColumnWidth(context, columnWidth))
+        this.columnWidth = getValidColumnWidth(context, columnWidth)
     }
 
-    private fun checkedColumnWidth(
+    private fun getValidColumnWidth(
         context: Context,
         columnWidth: Int,
     ): Int {
-        if (columnWidth <= 0) {
-            setColumnWidth(
-                TypedValue
-                    .applyDimension(
-                        TypedValue.COMPLEX_UNIT_DIP,
-                        48f,
-                        context.resources.displayMetrics,
-                    ).toInt(),
-            )
+        return if (columnWidth <= 0) {
+            TypedValue
+                .applyDimension(
+                    TypedValue.COMPLEX_UNIT_DIP,
+                    48f,
+                    context.resources.displayMetrics,
+                ).toInt()
+        } else {
+            columnWidth
         }
-        return columnWidth
     }
 
     fun setColumnWidth(newColumnWidth: Int) {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was confusing logic in the `GridAutofitLayoutManager` constructor. Specifically, the constructor called `setColumnWidth` which called a helper method `checkedColumnWidth` that had a side-effect call back to `setColumnWidth`.

💡 **Why:** This refactoring improves maintainability by:
- Removing confusing side effects from helper methods.
- Making the initialization flow in the constructor more direct and easier to reason about.
- Renaming the helper method to `getValidColumnWidth` to better reflect its purpose as a pure function.
- Fixing a subtle logic issue where invalid widths were effectively set twice.

✅ **Verification:** 
- Verified the code changes via `read_file`.
- Ran `GridAutofitLayoutManagerTest` and confirmed all tests pass.
- Ran the full test suite (`./gradlew test`) and confirmed all tests pass with no regressions.

✨ **Result:** The codebase now has a cleaner and more predictable `GridAutofitLayoutManager` implementation.

---
*PR created automatically by Jules for task [5539444646417555341](https://jules.google.com/task/5539444646417555341) started by @keeganwitt*