### PR TITLE
Add summary support for date and package manager fields

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -116,7 +116,7 @@ class MainActivity :
                             AppListViewModel(
                                 repo,
                                 DefaultDispatcherProvider(),
-                                SummaryCalculator(applicationContext),
+                                SummaryCalculator(applicationContext, store),
                             )
                         @Suppress("UNCHECKED_CAST")
                         return vm as T

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,4 +58,9 @@
     <string name="perm_bucket_many" translatable="false">11 – 20</string>
     <string name="perm_bucket_lots" translatable="false">20+</string>
 
+    <string name="date_bucket_last_month">Last month</string>
+    <string name="date_bucket_last_three_months">Last 3 months</string>
+    <string name="date_bucket_last_six_months">Last 6 months</string>
+    <string name="date_bucket_older">Older</string>
+
 </resources>


### PR DESCRIPTION
This change adds summary support for several app fields that were previously unsupported:
- FIRST_INSTALLED, LAST_UPDATED, and LAST_USED are now summarized into date-based buckets: "Last month", "Last 3 months", "Last 6 months", and "Older".
- PACKAGE_MANAGER is now summarized by grouping apps by their installer name (e.g., Google Play, F-Droid, APK, etc.) using the AppStoreService.

Changes:
- Modified `SummaryCalculator` to implement the bucketing logic for these fields.
- Updated `SummaryCalculator` constructor to require an `AppStoreService` instance.
- Updated `MainActivity` to pass the `AppStoreService` to the `SummaryCalculator`.
- Added new string resources for the date buckets in `strings.xml`.
- Added unit tests in `SummaryCalculatorTest` to verify the new summary logic.

---
*PR created automatically by Jules for task [8793148096373622619](https://jules.google.com/task/8793148096373622619) started by @keeganwitt*