### PR TITLE
Require usage stats permission for App Size field

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppInfoField.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppInfoField.kt
@@ -10,7 +10,7 @@ enum class AppInfoField(
     APK_SIZE(R.string.appInfoField_apkSize) {
         override fun getValue(app: App) = app.sizes.apkBytes
     },
-    APP_SIZE(R.string.appInfoField_appSize) {
+    APP_SIZE(R.string.appInfoField_appSize, requiresUsageStats = true) {
         override fun getValue(app: App) = app.sizes.appBytes
     },
     ARCHIVED(R.string.appInfoField_archived) {

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppInfoFieldTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppInfoFieldTest.kt
@@ -326,6 +326,7 @@ class AppInfoFieldTest {
 
     @Test
     fun `given field requiring usage stats, when accessed, then requiresUsageStats is true`() {
+        assertEquals(true, AppInfoField.APP_SIZE.requiresUsageStats)
         assertEquals(true, AppInfoField.CACHE_SIZE.requiresUsageStats)
         assertEquals(true, AppInfoField.DATA_SIZE.requiresUsageStats)
         assertEquals(true, AppInfoField.EXTERNAL_CACHE_SIZE.requiresUsageStats)
@@ -336,7 +337,6 @@ class AppInfoFieldTest {
     @Test
     fun `given field not requiring usage stats, when accessed, then requiresUsageStats is false`() {
         assertEquals(false, AppInfoField.APK_SIZE.requiresUsageStats)
-        assertEquals(false, AppInfoField.APP_SIZE.requiresUsageStats)
         assertEquals(false, AppInfoField.ARCHIVED.requiresUsageStats)
         assertEquals(false, AppInfoField.ENABLED.requiresUsageStats)
         assertEquals(false, AppInfoField.EXISTS_IN_APP_STORE.requiresUsageStats)


### PR DESCRIPTION
Updated `AppInfoField.APP_SIZE` to set `requiresUsageStats = true` because it requires the usage stats permission to retrieve accurate data. Also updated `AppInfoFieldTest.kt` to verify this change.

---
*PR created automatically by Jules for task [11209098466650470227](https://jules.google.com/task/11209098466650470227) started by @keeganwitt*