### PR TITLE
Add icon and improve display for summary menu item

### DIFF
--- a/app/src/main/res/drawable/ic_summary.xml
+++ b/app/src/main/res/drawable/ic_summary.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3zM9,17H7v-7h2V17zM13,17h-2V7h2V17zM17,17h-2v-4h2V17z"/>
+</vector>

--- a/app/src/main/res/menu/app_menu.xml
+++ b/app/src/main/res/menu/app_menu.xml
@@ -21,7 +21,8 @@
     app:showAsAction="ifRoom" />
   <item android:id="@+id/summary"
     android:title="@string/summary"
-    app:showAsAction="never" />
+    android:icon="@drawable/ic_summary"
+    app:showAsAction="ifRoom" />
   <item android:id="@+id/settings"
     android:title="@string/settings"
     app:showAsAction="never" />


### PR DESCRIPTION
Added a new vector drawable `ic_summary.xml` representing a bar chart/assessment icon. Updated `app/src/main/res/menu/app_menu.xml` to use this icon for the summary menu item and changed its `showAsAction` attribute to `ifRoom` so it can appear in the action bar when there is enough space, matching the behavior of the export/save button. Verified that the app builds and existing tests pass.

---
*PR created automatically by Jules for task [15202154199540834671](https://jules.google.com/task/15202154199540834671) started by @keeganwitt*