### PR TITLE
🧪 Test NameNotFoundException for getInstallerPackageName

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,7 +126,6 @@ val fileFilter =
     )
 
 tasks.withType<Test> {
-    maxHeapSize = "2g"
     configure<JacocoTaskExtension> {
         isIncludeNoLocationClasses = true
         excludes = listOf("jdk.internal.*")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,7 @@ val fileFilter =
     )
 
 tasks.withType<Test> {
+    maxHeapSize = "1g"
     configure<JacocoTaskExtension> {
         isIncludeNoLocationClasses = true
         excludes = listOf("jdk.internal.*")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,7 @@ val fileFilter =
     )
 
 tasks.withType<Test> {
+    maxHeapSize = "2g"
     configure<JacocoTaskExtension> {
         isIncludeNoLocationClasses = true
         excludes = listOf("jdk.internal.*")

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/services/PackageServiceTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/services/PackageServiceTest.kt
@@ -271,4 +271,39 @@ class PackageServiceTest {
 
         assertNull(result)
     }
+
+    @Test
+    @Config(sdk = [30])
+    fun `given SDK 30+, when getInstallSourceInfo throws NameNotFoundException, then getInstallerPackageName returns null`() {
+        val appInfo = ApplicationInfo().apply { packageName = "com.test.app" }
+        every { packageManager.getInstallSourceInfo("com.test.app") } throws PackageManager.NameNotFoundException()
+
+        val result = service.getInstallerPackageName(appInfo)
+
+        assertNull(result)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `given SDK 30+, when getInstallerPackageName called, then returns installer package name`() {
+        val appInfo = ApplicationInfo().apply { packageName = "com.test.app" }
+        val installSourceInfo = mockk<android.content.pm.InstallSourceInfo>()
+        every { installSourceInfo.installingPackageName } returns "com.android.vending"
+        every { packageManager.getInstallSourceInfo("com.test.app") } returns installSourceInfo
+
+        val result = service.getInstallerPackageName(appInfo)
+
+        assertEquals("com.android.vending", result)
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun `given legacy SDK, when getInstallerPackageName called, then returns installer package name`() {
+        val appInfo = ApplicationInfo().apply { packageName = "com.test.app" }
+        every { packageManager.getInstallerPackageName("com.test.app") } returns "com.android.vending"
+
+        val result = service.getInstallerPackageName(appInfo)
+
+        assertEquals("com.android.vending", result)
+    }
 }


### PR DESCRIPTION
This change improves test coverage for `AndroidPackageService.getInstallerPackageName` by adding unit tests that cover all its logic branches. Specifically, it addresses the request to test the `NameNotFoundException` catch block on API 30+, ensuring the method correctly returns `null` in that case. It also verifies the standard behavior on both modern and legacy Android versions.

---
*PR created automatically by Jules for task [5432585233590698425](https://jules.google.com/task/5432585233590698425) started by @keeganwitt*