### PR TITLE
🧪 Test generic Exception in AndroidStorageService

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,8 +114,6 @@ val fileFilter =
         "**/*Binding.class",
         "**/BR.class",
         // application classes
-        "**/AndroidStorageService*.class",
-        "**/AndroidUsageStatsService*.class",
         "**/AppAdapter*.class",
         "**/AppListApplication.class",
         "**/AppSettings.class",

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/services/StorageServiceTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/services/StorageServiceTest.kt
@@ -121,7 +121,7 @@ class StorageServiceTest {
     }
 
     @Test
-    fun `given queryStatsForPackage throws exception, when getStorageUsage called, then returns partial results`() {
+    fun `given queryStatsForPackage throws SecurityException, when getStorageUsage called, then returns partial results`() {
         val appInfo = ApplicationInfo().apply { packageName = "com.test.app" }
         val storageVolume = mockk<StorageVolume>()
         val testUuid = UUID.randomUUID()
@@ -134,6 +134,50 @@ class StorageServiceTest {
         val result = service.getStorageUsage(appInfo)
 
         assertEquals(0L, result.totalBytes)
+    }
+
+    @Test
+    fun `given queryStatsForPackage throws generic exception, when getStorageUsage called, then returns partial results`() {
+        val appInfo = ApplicationInfo().apply { packageName = "com.test.app" }
+        val storageVolume = mockk<StorageVolume>()
+        val testUuid = UUID.randomUUID()
+
+        every { storageVolume.state } returns Environment.MEDIA_MOUNTED
+        every { storageVolume.uuid } returns testUuid.toString()
+        every { storageManager.storageVolumes } returns listOf(storageVolume)
+        every { storageStatsManager.queryStatsForPackage(testUuid, "com.test.app", any()) } throws RuntimeException("Something went wrong")
+
+        val result = service.getStorageUsage(appInfo)
+
+        assertEquals(0L, result.totalBytes)
+    }
+
+    @Test
+    fun `given multiple volumes and one throws generic exception, when getStorageUsage called, then returns results from other volumes`() {
+        val appInfo = ApplicationInfo().apply { packageName = "com.test.app" }
+        val volume1 = mockk<StorageVolume>()
+        val volume2 = mockk<StorageVolume>()
+        val stats2 = mockk<StorageStats>()
+        val uuid1 = UUID.randomUUID()
+        val uuid2 = UUID.randomUUID()
+
+        every { volume1.state } returns Environment.MEDIA_MOUNTED
+        every { volume1.uuid } returns uuid1.toString()
+        every { volume2.state } returns Environment.MEDIA_MOUNTED
+        every { volume2.uuid } returns uuid2.toString()
+        every { storageManager.storageVolumes } returns listOf(volume1, volume2)
+
+        every { storageStatsManager.queryStatsForPackage(uuid1, "com.test.app", any()) } throws RuntimeException("Error on volume 1")
+        every { stats2.appBytes } returns 1000L
+        every { stats2.cacheBytes } returns 2000L
+        every { stats2.dataBytes } returns 3000L
+        every { storageStatsManager.queryStatsForPackage(uuid2, "com.test.app", any()) } returns stats2
+
+        val result = service.getStorageUsage(appInfo)
+
+        assertEquals(1000L, result.appBytes)
+        assertEquals(2000L, result.cacheBytes)
+        assertEquals(3000L, result.dataBytes)
     }
 
     @Test

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,8 +10,6 @@ coverage:
         threshold: 1%
 
 ignore:
-  - "app/src/main/kotlin/**/AndroidStorageService.kt"
-  - "app/src/main/kotlin/**/AndroidUsageStatsService.kt"
   - "app/src/main/kotlin/**/AppAdapter.kt"
   - "app/src/main/kotlin/**/AppExporter.kt"
   - "app/src/main/kotlin/**/AppListApplication.kt"


### PR DESCRIPTION
This change improves the test coverage for `AndroidStorageService` by specifically testing the catch block for generic `Exception`. It ensures that if `queryStatsForPackage` throws an unexpected exception, the service still returns whatever data it was able to collect from other volumes.

Two new test cases were added:
1. `given queryStatsForPackage throws generic exception, when getStorageUsage called, then returns partial results`
2. `given multiple volumes and one throws generic exception, when getStorageUsage called, then returns results from other volumes`

The existing test `given queryStatsForPackage throws exception` was renamed to `given queryStatsForPackage throws SecurityException` to better reflect its purpose.

---
*PR created automatically by Jules for task [5867756160608961652](https://jules.google.com/task/5867756160608961652) started by @keeganwitt*