### PR TITLE
🧹 [code health] Refactor manual time period calculations to use TimeUnit

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/SummaryCalculator.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/SummaryCalculator.kt
@@ -20,6 +20,7 @@ import com.github.keeganwitt.applist.AppInfoField.TARGET_SDK
 import com.github.keeganwitt.applist.AppInfoField.TOTAL_SIZE
 import com.github.keeganwitt.applist.AppInfoField.VERSION
 import com.github.keeganwitt.applist.services.AppStoreService
+import java.util.concurrent.TimeUnit
 
 data class SummaryItem(
     val field: AppInfoField,
@@ -218,9 +219,9 @@ class SummaryCalculator(
         orderedBuckets[older] = 0
 
         val now = System.currentTimeMillis()
-        val oneMonthAgo = now - 30L * 24 * 60 * 60 * 1000
-        val threeMonthsAgo = now - 90L * 24 * 60 * 60 * 1000
-        val sixMonthsAgo = now - 180L * 24 * 60 * 60 * 1000
+        val oneMonthAgo = now - TimeUnit.DAYS.toMillis(30)
+        val threeMonthsAgo = now - TimeUnit.DAYS.toMillis(90)
+        val sixMonthsAgo = now - TimeUnit.DAYS.toMillis(180)
 
         timestamps.forEach { timestamp ->
             val key =

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/SummaryCalculatorTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/SummaryCalculatorTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.github.keeganwitt.applist.services.AppStoreService
 import io.mockk.every
 import io.mockk.mockk
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -174,10 +175,10 @@ class SummaryCalculatorTest {
     fun `calculateDateSummary buckets correctly`() {
         mockStrings()
         val now = System.currentTimeMillis()
-        val oneMonthAgo = now - 15L * 24 * 60 * 60 * 1000
-        val threeMonthsAgo = now - 45L * 24 * 60 * 60 * 1000
-        val sixMonthsAgo = now - 120L * 24 * 60 * 60 * 1000
-        val older = now - 200L * 24 * 60 * 60 * 1000
+        val oneMonthAgo = now - TimeUnit.DAYS.toMillis(15)
+        val threeMonthsAgo = now - TimeUnit.DAYS.toMillis(45)
+        val sixMonthsAgo = now - TimeUnit.DAYS.toMillis(120)
+        val older = now - TimeUnit.DAYS.toMillis(200)
 
         val app1 = createApp(enabled = true, archived = false, apkSize = 0).copy(firstInstalled = oneMonthAgo)
         val app2 = createApp(enabled = true, archived = false, apkSize = 0).copy(firstInstalled = threeMonthsAgo)
@@ -196,7 +197,7 @@ class SummaryCalculatorTest {
     fun `calculateDateSummary handles boundary cases correctly`() {
         mockStrings()
         val now = System.currentTimeMillis()
-        val dayMs = 24L * 60 * 60 * 1000
+        val dayMs = TimeUnit.DAYS.toMillis(1)
 
         val apps =
             listOf(


### PR DESCRIPTION
This PR refactors manual time period calculations in `SummaryCalculator.kt` and its associated tests to use the `java.util.concurrent.TimeUnit` API. 

The original code used manual multiplications (e.g., `30L * 24 * 60 * 60 * 1000`) to represent time durations in milliseconds. These have been replaced with `TimeUnit.DAYS.toMillis(30)`, which is clearer, less error-prone, and more expressive.

Key changes:
- Updated `SummaryCalculator.calculateDateSummary` to use `TimeUnit`.
- Updated `SummaryCalculatorTest` date-related tests to use `TimeUnit` for consistency.
- Added necessary imports for `java.util.concurrent.TimeUnit`.

The changes were manually verified for mathematical correctness. Attempts to run the full test suite via Gradle were hindered by environment-specific timeouts (400s task limit and Gradle Wrapper download issues).

---
*PR created automatically by Jules for task [8107573509025748323](https://jules.google.com/task/8107573509025748323) started by @keeganwitt*