### PR TITLE
[codex] Add clickable store URLs

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppAdapter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppAdapter.kt
@@ -1,9 +1,13 @@
 package com.github.keeganwitt.applist
 
+import android.text.SpannableString
+import android.text.Spanned
 import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -44,13 +48,46 @@ class AppAdapter(
 
         binding.packageName.text = item.packageName
         binding.appName.text = item.appName
-        binding.appInfo.movementMethod = LinkMovementMethod.getInstance()
-        binding.appInfo.text = item.infoText
+        bindAppInfo(binding.appInfo, item)
         binding.appInfo.visibility = if (item.infoText.isBlank()) View.GONE else View.VISIBLE
+    }
+
+    private fun bindAppInfo(
+        appInfo: TextView,
+        item: AppItemUiModel,
+    ) {
+        val infoUrl = item.infoUrl
+        if (infoUrl == null) {
+            appInfo.text = item.infoText
+            appInfo.movementMethod = null
+            appInfo.linksClickable = false
+            appInfo.isClickable = false
+            return
+        }
+
+        val linkText =
+            SpannableString(item.infoText).apply {
+                setSpan(
+                    object : ClickableSpan() {
+                        override fun onClick(widget: View) {
+                            onClickListener.onStoreUrlClick(infoUrl)
+                        }
+                    },
+                    0,
+                    item.infoText.length,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+            }
+        appInfo.text = linkText
+        appInfo.movementMethod = LinkMovementMethod.getInstance()
+        appInfo.linksClickable = true
+        appInfo.isClickable = true
     }
 
     interface OnClickListener {
         fun onClick(position: Int)
+
+        fun onStoreUrlClick(url: String)
     }
 
     inner class AppInfoViewHolder(

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppItemUiModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppItemUiModel.kt
@@ -4,5 +4,6 @@ data class AppItemUiModel(
     val packageName: String,
     val appName: String,
     val infoText: String,
+    val infoUrl: String? = null,
     val isLoading: Boolean = false,
 )

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -163,7 +163,8 @@ class AppListViewModel(
                 ""
             } else if (field in app.failedFields) {
                 loadingFailedValue
-            } else if (field.isSize && rawValue is Long &&
+            } else if (field.isSize &&
+                rawValue is Long &&
                 (rawValue > 0 || (field != AppInfoField.APK_SIZE && field != AppInfoField.TOTAL_SIZE))
             ) {
                 sizeFormatter(rawValue)
@@ -174,6 +175,7 @@ class AppListViewModel(
             packageName = app.packageName,
             appName = app.name,
             infoText = info,
+            infoUrl = info.takeIf { field == AppInfoField.STORE_URL && it.isNotBlank() },
             isLoading = !app.isDetailed,
         )
     }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -310,6 +310,10 @@ class MainActivity :
         startActivity(intent)
     }
 
+    override fun onStoreUrlClick(url: String) {
+        startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+    }
+
     override fun onItemSelected(
         parent: AdapterView<*>,
         view: View?,

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppAdapterTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppAdapterTest.kt
@@ -1,7 +1,14 @@
 package com.github.keeganwitt.applist
 
+import android.text.Spanned
+import android.text.style.ClickableSpan
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -58,5 +65,36 @@ class AppAdapterTest {
         adapter.submitList(listOf(item2))
 
         assertEquals(1, adapter.currentList.size)
+    }
+
+    @Test
+    fun `given item without infoUrl, when bound, then app info is not clickable`() {
+        val holder = createViewHolder()
+        adapter.submitList(listOf(AppItemUiModel("com.test.app", "App", "1.0.0")))
+
+        adapter.onBindViewHolder(holder, 0)
+
+        assertFalse(holder.binding.appInfo.isClickable)
+    }
+
+    @Test
+    fun `given item with infoUrl, when bound and link clicked, then store URL click is reported`() {
+        val url = "https://play.google.com/store/apps/details?id=com.test.app"
+        val holder = createViewHolder()
+        adapter.submitList(listOf(AppItemUiModel("com.test.app", "App", url, infoUrl = url)))
+
+        adapter.onBindViewHolder(holder, 0)
+        val spanned = holder.binding.appInfo.text as Spanned
+        val spans = spanned.getSpans(0, spanned.length, ClickableSpan::class.java)
+        spans.single().onClick(holder.binding.appInfo)
+
+        assertTrue(holder.binding.appInfo.isClickable)
+        verify { onClickListener.onStoreUrlClick(url) }
+    }
+
+    private fun createViewHolder(): AppAdapter.AppInfoViewHolder {
+        val context = ApplicationProvider.getApplicationContext<TestAppListApplication>()
+        val parent = FrameLayout(context)
+        return adapter.onCreateViewHolder(parent, 0)
     }
 }

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppItemUiModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppItemUiModelTest.kt
@@ -18,7 +18,21 @@ class AppItemUiModelTest {
         assertEquals("com.test.app", model.packageName)
         assertEquals("Test App", model.appName)
         assertEquals("1.0.0", model.infoText)
+        assertEquals(null, model.infoUrl)
         assertFalse(model.isLoading)
+    }
+
+    @Test
+    fun `given AppItemUiModel created with infoUrl, then infoUrl is set`() {
+        val model =
+            AppItemUiModel(
+                packageName = "com.test.app",
+                appName = "Test App",
+                infoText = "https://test.url",
+                infoUrl = "https://test.url",
+            )
+
+        assertEquals("https://test.url", model.infoUrl)
     }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -333,6 +333,26 @@ class AppListViewModelTest {
         }
 
     @Test
+    fun `given store URL field, when mapToItem called, then info URL is set`() =
+        runTest {
+            val storeUrl = "https://play.google.com/store/apps/details?id=com.test.app"
+            val app = createTestApp("com.test.app", "Test App").copy(storeUrl = storeUrl)
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+
+            viewModel.init(
+                AppInfoField.STORE_URL,
+                initialShowSystem = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val item = viewModel.uiState.value.items[0]
+            assertEquals(storeUrl, item.infoText)
+            assertEquals(storeUrl, item.infoUrl)
+        }
+
+    @Test
     fun `given size field, when mapToItem called, then sizeFormatter is used`() =
         runTest {
             val app = createTestApp("com.test.app", "Test App").copy(sizes = StorageUsage(apkBytes = 1024))


### PR DESCRIPTION
## Summary
- make the displayed store URL clickable when Store URL is the selected app info field
- preserve the existing row tap behavior for opening Android app details
- add adapter, UI model, and view-model tests for the URL metadata and click callback

## Validation
- `./gradlew.bat :app:testDebugUnitTest --tests com.github.keeganwitt.applist.AppAdapterTest --tests com.github.keeganwitt.applist.AppItemUiModelTest --tests com.github.keeganwitt.applist.AppListViewModelTest`

## Notes
- `./gradlew.bat :app:ktlintCheck` still fails on existing lint issues outside this change, including wildcard imports, line length, and older main-source style violations.