### PR TITLE
[codex] Fix export MIME types

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
@@ -1,11 +1,14 @@
 package com.github.keeganwitt.applist
 
+import android.app.Activity
+import android.content.Context
 import android.content.DialogInterface
+import android.content.Intent
 import android.net.Uri
 import android.widget.RadioGroup
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.ActivityResultRegistry
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -28,7 +31,21 @@ class AppExporter(
         registry.register(
             "app_exporter_${System.identityHashCode(this)}",
             activity,
-            ActivityResultContracts.CreateDocument("text/plain"),
+            object : ActivityResultContract<ExportFormat, Uri?>() {
+                override fun createIntent(
+                    context: Context,
+                    input: ExportFormat,
+                ): Intent =
+                    Intent(Intent.ACTION_CREATE_DOCUMENT)
+                        .addCategory(Intent.CATEGORY_OPENABLE)
+                        .setType(input.mimeType)
+                        .putExtra(Intent.EXTRA_TITLE, "app-list.${input.extension}")
+
+                override fun parseResult(
+                    resultCode: Int,
+                    intent: Intent?,
+                ): Uri? = if (resultCode == Activity.RESULT_OK) intent?.data else null
+            },
         ) { uri ->
             uri?.let {
                 val format = pendingExportFormat ?: ExportFormat.XML
@@ -55,7 +72,7 @@ class AppExporter(
                         else -> ExportFormat.XML
                     }
                 pendingExportFormat = format
-                exportLauncher.launch("app-list." + format.extension)
+                exportLauncher.launch(format)
             }.setNegativeButton(android.R.string.cancel, null)
             .show()
     }

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppExporterTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppExporterTest.kt
@@ -1,7 +1,9 @@
 package com.github.keeganwitt.applist
 
+import android.app.Activity
 import android.content.ContentProvider
 import android.content.ContentValues
+import android.content.Intent
 import android.database.Cursor
 import android.net.Uri
 import androidx.activity.result.ActivityResultCallback
@@ -130,7 +132,7 @@ class AppExporterTest {
             registry.register(
                 any(),
                 any(),
-                any<ActivityResultContract<String, Uri?>>(),
+                any<ActivityResultContract<ExportFormat, Uri?>>(),
                 capture(callbackSlot),
             )
         } returns mockk(relaxed = true)
@@ -163,7 +165,7 @@ class AppExporterTest {
             registry.register(
                 any(),
                 any(),
-                any<ActivityResultContract<String, Uri?>>(),
+                any<ActivityResultContract<ExportFormat, Uri?>>(),
                 capture(callbackSlot),
             )
         } returns mockk(relaxed = true)
@@ -454,7 +456,7 @@ class AppExporterTest {
             registry.register(
                 any(),
                 any(),
-                any<ActivityResultContract<String, Uri?>>(),
+                any<ActivityResultContract<ExportFormat, Uri?>>(),
                 capture(callbackSlot),
             )
         } returns mockk(relaxed = true)
@@ -475,7 +477,7 @@ class AppExporterTest {
             registry.register(
                 any(),
                 any(),
-                any<ActivityResultContract<String, Uri?>>(),
+                any<ActivityResultContract<ExportFormat, Uri?>>(),
                 capture(callbackSlot),
             )
         } returns mockk(relaxed = true)
@@ -514,14 +516,41 @@ class AppExporterTest {
     }
 
     @Test
-    fun export_selectsCsv_launchesCsvPicker() {
+    fun export_createDocumentIntentUsesSelectedFormatMimeTypeAndTitle() {
         val registry = mockk<ActivityResultRegistry>(relaxed = true)
-        val launcher = mockk<ActivityResultLauncher<String>>(relaxed = true)
+        val contractSlot = slot<ActivityResultContract<ExportFormat, Uri?>>()
         every {
             registry.register(
                 any(),
                 any(),
-                any<ActivityResultContract<String, Uri?>>(),
+                capture(contractSlot),
+                any(),
+            )
+        } returns mockk<ActivityResultLauncher<ExportFormat>>(relaxed = true)
+
+        AppExporter(activity, repository, formatter, appSettings, crashReporter, testDispatchers, registry)
+
+        ExportFormat.entries.forEach { format ->
+            val intent = contractSlot.captured.createIntent(activity, format)
+            assertEquals(Intent.ACTION_CREATE_DOCUMENT, intent.action)
+            assertTrue(intent.categories?.contains(Intent.CATEGORY_OPENABLE) == true)
+            assertEquals(format.mimeType, intent.type)
+            assertEquals("app-list.${format.extension}", intent.getStringExtra(Intent.EXTRA_TITLE))
+        }
+
+        val uri = Uri.parse("content://dummy/export")
+        assertEquals(uri, contractSlot.captured.parseResult(Activity.RESULT_OK, Intent().setData(uri)))
+    }
+
+    @Test
+    fun export_selectsCsv_launchesCsvPicker() {
+        val registry = mockk<ActivityResultRegistry>(relaxed = true)
+        val launcher = mockk<ActivityResultLauncher<ExportFormat>>(relaxed = true)
+        every {
+            registry.register(
+                any(),
+                any(),
+                any<ActivityResultContract<ExportFormat, Uri?>>(),
                 any(),
             )
         } returns launcher
@@ -540,18 +569,18 @@ class AppExporterTest {
         dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE).performClick()
         Shadows.shadowOf(activity.mainLooper).idle()
 
-        verify { launcher.launch(match { it.endsWith(".csv") }) }
+        verify { launcher.launch(ExportFormat.CSV) }
     }
 
     @Test
     fun export_selectsHtml_launchesHtmlPicker() {
         val registry = mockk<ActivityResultRegistry>(relaxed = true)
-        val launcher = mockk<ActivityResultLauncher<String>>(relaxed = true)
+        val launcher = mockk<ActivityResultLauncher<ExportFormat>>(relaxed = true)
         every {
             registry.register(
                 any(),
                 any(),
-                any<ActivityResultContract<String, Uri?>>(),
+                any<ActivityResultContract<ExportFormat, Uri?>>(),
                 any(),
             )
         } returns launcher
@@ -570,18 +599,18 @@ class AppExporterTest {
         dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE).performClick()
         Shadows.shadowOf(activity.mainLooper).idle()
 
-        verify { launcher.launch(match { it.endsWith(".html") }) }
+        verify { launcher.launch(ExportFormat.HTML) }
     }
 
     @Test
     fun export_selectsTsv_launchesTsvPicker() {
         val registry = mockk<ActivityResultRegistry>(relaxed = true)
-        val launcher = mockk<ActivityResultLauncher<String>>(relaxed = true)
+        val launcher = mockk<ActivityResultLauncher<ExportFormat>>(relaxed = true)
         every {
             registry.register(
                 any(),
                 any(),
-                any<ActivityResultContract<String, Uri?>>(),
+                any<ActivityResultContract<ExportFormat, Uri?>>(),
                 any(),
             )
         } returns launcher
@@ -600,6 +629,6 @@ class AppExporterTest {
         dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE).performClick()
         Shadows.shadowOf(activity.mainLooper).idle()
 
-        verify { launcher.launch(match { it.endsWith(".tsv") }) }
+        verify { launcher.launch(ExportFormat.TSV) }
     }
 }


### PR DESCRIPTION
## Summary
- create exported documents with the selected format MIME type instead of text/plain
- preserve the matching default filename for XML, HTML, CSV, and TSV exports
- cover all export formats in the create-document intent test

## Validation
- .\gradlew.bat testDebugUnitTest --tests com.github.keeganwitt.applist.AppExporterTest