### PR TITLE
🧹 Extract duplicate logic in writeCsv and writeTsv

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/ExportFormatter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/ExportFormatter.kt
@@ -109,20 +109,8 @@ class ExportFormatter {
         apps: List<App>,
         includeUsageStats: Boolean,
     ) {
-        val fields = AppInfoField.entries.filter { includeUsageStats || !it.requiresUsageStats }
-        writer.append("App Name,Package Name")
-        fields.forEach { field ->
-            writer.append(",").append(field.name)
-        }
-        writer.append("\n")
-
-        apps.forEach { app ->
-            writer.append("\"").append(app.name.replace("\"", "\"\"")).append("\",")
-            writer.append("\"").append(app.packageName.replace("\"", "\"\"")).append("\"")
-            fields.forEach { field ->
-                writer.append(",\"").append(field.getFormattedValue(app).replace("\"", "\"\"")).append("\"")
-            }
-            writer.append("\n")
+        writeDelimited(writer, apps, includeUsageStats, ",") { value ->
+            "\"${value.replace("\"", "\"\"")}\""
         }
     }
 
@@ -131,18 +119,28 @@ class ExportFormatter {
         apps: List<App>,
         includeUsageStats: Boolean,
     ) {
+        writeDelimited(writer, apps, includeUsageStats, "\t") { it.escapeTsv() }
+    }
+
+    private fun writeDelimited(
+        writer: Writer,
+        apps: List<App>,
+        includeUsageStats: Boolean,
+        delimiter: String,
+        escape: (String) -> String,
+    ) {
         val fields = AppInfoField.entries.filter { includeUsageStats || !it.requiresUsageStats }
-        writer.append("App Name\tPackage Name")
+        writer.append("App Name").append(delimiter).append("Package Name")
         fields.forEach { field ->
-            writer.append("\t").append(field.name)
+            writer.append(delimiter).append(field.name)
         }
         writer.append("\n")
 
         apps.forEach { app ->
-            writer.append(app.name.escapeTsv()).append("\t")
-            writer.append(app.packageName.escapeTsv())
+            writer.append(escape(app.name)).append(delimiter)
+            writer.append(escape(app.packageName))
             fields.forEach { field ->
-                writer.append("\t").append(field.getFormattedValue(app).escapeTsv())
+                writer.append(delimiter).append(escape(field.getFormattedValue(app)))
             }
             writer.append("\n")
         }


### PR DESCRIPTION
🎯 **What:** Extracted the common logic for CSV and TSV export in `ExportFormatter.kt` into a new private helper function `writeDelimited`.
💡 **Why:** This improves maintainability and readability by eliminating code duplication. The shared structure (headers, row iteration, field collection) is now centralized, while format-specific details (delimiter, escaping) are passed as parameters.
✅ **Verification:** Performed a detailed manual inspection of the refactored code to ensure logic parity with the original implementation. The escaping strategies for both CSV (quoting) and TSV (backslash escaping) remain unchanged. A code review was also completed with a "Correct" rating.
✨ **Result:** Reduced code duplication in `ExportFormatter.kt` and improved the modularity of the export logic.

---
*PR created automatically by Jules for task [969714186021218065](https://jules.google.com/task/969714186021218065) started by @keeganwitt*