### PR TITLE
Fix system apps filter toggle

### DIFF
--- a/app/src/androidTest/kotlin/com/github/keeganwitt/applist/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/com/github/keeganwitt/applist/MainActivityTest.kt
@@ -2,6 +2,8 @@ package com.github.keeganwitt.applist
 
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.appcompat.view.menu.MenuBuilder
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -22,6 +24,13 @@ class MainActivityTest {
 
     @Before
     fun setup() {
+        InstrumentationRegistry
+            .getInstrumentation()
+            .targetContext
+            .getSharedPreferences(
+                InstrumentationRegistry.getInstrumentation().targetContext.packageName + AppSettings.DEFAULT_PREF_NAME_SUFFIX,
+                android.content.Context.MODE_PRIVATE,
+            ).edit().clear().commit()
         scenario = ActivityScenario.launch(MainActivity::class.java)
         waitFor(3000)
     }
@@ -62,6 +71,29 @@ class MainActivityTest {
         onView(withId(R.id.toggleButton)).perform(click())
         waitFor(500)
         onView(withId(R.id.toggleButton)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun mainActivity_whenSystemAppsToggleClicked_thenCheckedStateAndIconChange() {
+        scenario.onActivity { activity ->
+            val menu = MenuBuilder(activity)
+            activity.onCreateOptionsMenu(menu)
+            val item = menu.findItem(R.id.systemAppToggle)
+
+            assertEquals(false, item.isChecked)
+            assertEquals(
+                activity.getDrawable(R.drawable.ic_system_apps_on)?.constantState,
+                item.icon?.constantState,
+            )
+
+            activity.onOptionsItemSelected(item)
+
+            assertEquals(true, item.isChecked)
+            assertEquals(
+                activity.getDrawable(R.drawable.ic_system_apps_off)?.constantState,
+                item.icon?.constantState,
+            )
+        }
     }
 
     @Test

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -34,14 +34,14 @@ class AppListViewModel(
 
     fun init(
         initialField: AppInfoField,
-        initialShowSystem: Boolean,
+        initialSystemAppsOnly: Boolean,
         initialShowArchived: Boolean,
         initialDescending: Boolean,
     ) {
         _uiState.update {
             it.copy(
                 selectedField = initialField,
-                showSystem = initialShowSystem,
+                systemAppsOnly = initialSystemAppsOnly,
                 showArchived = initialShowArchived,
                 descending = initialDescending,
             )
@@ -63,8 +63,8 @@ class AppListViewModel(
         setDescending(!_uiState.value.descending)
     }
 
-    fun setShowSystem(show: Boolean) {
-        _uiState.update { it.copy(showSystem = show) }
+    fun setSystemAppsOnly(enabled: Boolean) {
+        _uiState.update { it.copy(systemAppsOnly = enabled) }
         loadApps(reload = true)
     }
 
@@ -94,7 +94,7 @@ class AppListViewModel(
                 repository
                     .loadApps(
                         field = state.selectedField,
-                        showSystemApps = state.showSystem,
+                        systemAppsOnly = state.systemAppsOnly,
                         showArchivedApps = state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
                         descending = state.descending,
                         reload = reload,

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
@@ -40,7 +40,7 @@ sealed class SyncState {
 interface AppRepository {
     fun loadApps(
         field: AppInfoField,
-        showSystemApps: Boolean,
+        systemAppsOnly: Boolean,
         showArchivedApps: Boolean,
         descending: Boolean,
         reload: Boolean,
@@ -68,7 +68,7 @@ class AndroidAppRepository(
 
     override fun loadApps(
         field: AppInfoField,
-        showSystemApps: Boolean,
+        systemAppsOnly: Boolean,
         showArchivedApps: Boolean,
         descending: Boolean,
         reload: Boolean,
@@ -78,7 +78,7 @@ class AndroidAppRepository(
             val initialEntities = appDao.getAllApps()
             if (initialEntities.isNotEmpty()) {
                 val apps = initialEntities.map { it.toDomainModel() }
-                send(sortAndFilter(apps, field, showSystemApps, showArchivedApps, descending))
+                send(sortAndFilter(apps, field, systemAppsOnly, showArchivedApps, descending))
             }
 
             // Trigger sync in background if needed or if reload is true
@@ -89,14 +89,14 @@ class AndroidAppRepository(
             // Now observe DB for updates
             appDao.getAllAppsFlow().collect { entities ->
                 val apps = entities.map { it.toDomainModel() }
-                send(sortAndFilter(apps, field, showSystemApps, showArchivedApps, descending))
+                send(sortAndFilter(apps, field, systemAppsOnly, showArchivedApps, descending))
             }
         }
 
     private fun sortAndFilter(
         apps: List<App>,
         field: AppInfoField,
-        showSystemApps: Boolean,
+        systemAppsOnly: Boolean,
         showArchivedApps: Boolean,
         descending: Boolean,
     ): List<App> {
@@ -106,7 +106,7 @@ class AndroidAppRepository(
                 val isUserInstalled = app.isUserInstalled
                 val hasLaunch = app.hasLaunchIntent
                 val isVisible = if (archived) showArchivedApps else hasLaunch
-                (showSystemApps || isUserInstalled) && isVisible
+                (if (systemAppsOnly) !isUserInstalled else isUserInstalled) && isVisible
             }
         return sortApps(filtered, field, descending)
     }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppSettings.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppSettings.kt
@@ -21,9 +21,9 @@ interface AppSettings {
 
     fun setIncludeUsageStatsInExportEnabled(enabled: Boolean)
 
-    fun isShowSystemAppsEnabled(): Boolean
+    fun isSystemAppsOnlyEnabled(): Boolean
 
-    fun setShowSystemAppsEnabled(enabled: Boolean)
+    fun setSystemAppsOnlyEnabled(enabled: Boolean)
 
     fun isShowArchivedAppsEnabled(): Boolean
 
@@ -107,9 +107,9 @@ class SharedPreferencesAppSettings(
         preferences.edit { putBoolean(AppSettings.KEY_INCLUDE_USAGE_STATS_IN_EXPORT, enabled) }
     }
 
-    override fun isShowSystemAppsEnabled(): Boolean = preferences.getBoolean(AppSettings.KEY_SHOW_SYSTEM_APPS, false)
+    override fun isSystemAppsOnlyEnabled(): Boolean = preferences.getBoolean(AppSettings.KEY_SHOW_SYSTEM_APPS, false)
 
-    override fun setShowSystemAppsEnabled(enabled: Boolean) {
+    override fun setSystemAppsOnlyEnabled(enabled: Boolean) {
         preferences.edit { putBoolean(AppSettings.KEY_SHOW_SYSTEM_APPS, enabled) }
     }
 

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -170,7 +170,7 @@ class MainActivity :
             binding.spinner.onItemSelectedListener = this
             appListViewModel.init(
                 AppInfoField.DEFAULT,
-                appSettings.isShowSystemAppsEnabled(),
+                appSettings.isSystemAppsOnlyEnabled(),
                 appSettings.isShowArchivedAppsEnabled(),
                 appSettings.isDescending(),
             )
@@ -186,7 +186,7 @@ class MainActivity :
             binding.spinner.onItemSelectedListener = this
             appListViewModel.init(
                 lastDisplayedField,
-                appSettings.isShowSystemAppsEnabled(),
+                appSettings.isSystemAppsOnlyEnabled(),
                 appSettings.isShowArchivedAppsEnabled(),
                 appSettings.isDescending(),
             )
@@ -214,7 +214,7 @@ class MainActivity :
                     val shouldInvalidate =
                         latestState.isFullyLoaded != state.isFullyLoaded ||
                             (latestState.summary == null) != (state.summary == null) ||
-                            latestState.showSystem != state.showSystem ||
+                            latestState.systemAppsOnly != state.systemAppsOnly ||
                             latestState.showArchived != state.showArchived ||
                             latestState.selectedField != state.selectedField
                     latestState = state
@@ -256,7 +256,8 @@ class MainActivity :
         ignoreQueryChanges = false
         menuInflater.inflate(R.menu.app_menu, menu)
 
-        menu.findItem(R.id.systemAppToggle).isChecked = latestState.showSystem
+        val systemAppsToggle = menu.findItem(R.id.systemAppToggle)
+        updateSystemAppsToggle(systemAppsToggle, latestState.systemAppsOnly)
 
         val archivedToggle = menu.findItem(R.id.archivedAppToggle)
         val isArchivedFieldSelected = latestState.selectedField == AppInfoField.ARCHIVED
@@ -378,9 +379,10 @@ class MainActivity :
             }
 
             R.id.systemAppToggle -> {
-                val newValue = !latestState.showSystem
-                appListViewModel.setShowSystem(newValue)
-                appSettings.setShowSystemAppsEnabled(newValue)
+                val newValue = !latestState.systemAppsOnly
+                appListViewModel.setSystemAppsOnly(newValue)
+                appSettings.setSystemAppsOnlyEnabled(newValue)
+                updateSystemAppsToggle(item, newValue)
                 return true
             }
 
@@ -425,6 +427,14 @@ class MainActivity :
             .setView(view)
             .setPositiveButton(android.R.string.ok, null)
             .show()
+    }
+
+    private fun updateSystemAppsToggle(
+        item: MenuItem,
+        systemAppsOnly: Boolean,
+    ) {
+        item.isChecked = systemAppsOnly
+        item.setIcon(if (systemAppsOnly) R.drawable.ic_system_apps_off else R.drawable.ic_system_apps_on)
     }
 
     private fun maybeRequestUsagePermission(

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/UiState.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/UiState.kt
@@ -2,7 +2,7 @@ package com.github.keeganwitt.applist
 
 data class UiState(
     val selectedField: AppInfoField = AppInfoField.DEFAULT,
-    val showSystem: Boolean = false,
+    val systemAppsOnly: Boolean = false,
     val showArchived: Boolean = false,
     val descending: Boolean = false,
     val query: String = "",

--- a/app/src/main/res/menu/app_menu.xml
+++ b/app/src/main/res/menu/app_menu.xml
@@ -12,7 +12,7 @@
   <item
       android:id="@+id/systemAppToggle"
       android:title="@string/systemAppToggle"
-      android:icon="@drawable/system_apps_toggle_selector"
+      android:icon="@drawable/ic_system_apps_on"
       android:checkable="true"
       app:showAsAction="ifRoom" />
   <item

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -67,7 +67,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -81,7 +81,7 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = false,
@@ -97,7 +97,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -112,7 +112,7 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.TARGET_SDK,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = false,
@@ -128,7 +128,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -144,7 +144,7 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = true,
                     reload = false,
@@ -153,7 +153,7 @@ class AppListViewModelTest {
         }
 
     @Test
-    fun `given apps loaded, when setShowSystem called with true, then system apps are shown`() =
+    fun `given apps loaded, when setSystemAppsOnly called with true, then system apps are shown`() =
         runTest {
             val mockApps =
                 listOf(
@@ -164,22 +164,22 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
             advanceUntilIdle()
 
-            viewModel.setShowSystem(true)
+            viewModel.setSystemAppsOnly(true)
             advanceUntilIdle()
 
             val state = viewModel.uiState.value
-            assertTrue(state.showSystem)
+            assertTrue(state.systemAppsOnly)
             coVerify {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = true,
+                    systemAppsOnly = true,
                     showArchivedApps = false,
                     descending = false,
                     reload = true,
@@ -200,7 +200,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -241,7 +241,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -265,7 +265,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -278,7 +278,7 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = any(),
@@ -288,7 +288,7 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = true,
@@ -303,7 +303,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -322,7 +322,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -341,7 +341,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.STORE_URL,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -363,7 +363,7 @@ class AppListViewModelTest {
 
             viewModelWithSizeFormatter.init(
                 AppInfoField.APK_SIZE,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -385,7 +385,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -410,7 +410,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -438,7 +438,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -457,7 +457,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -478,7 +478,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -502,7 +502,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.ENABLED,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -522,7 +522,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.ENABLED,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -551,7 +551,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.ENABLED,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -577,7 +577,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -602,7 +602,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -671,7 +671,7 @@ class AppListViewModelTest {
                 coEvery { repository.loadApps(field, any(), any(), any(), any()) } returns flowOf(listOf(app))
                 viewModel.init(
                     field,
-                    initialShowSystem = false,
+                    initialSystemAppsOnly = false,
                     initialShowArchived = false,
                     initialDescending = false,
                 )
@@ -733,7 +733,7 @@ class AppListViewModelTest {
                 coEvery { repository.loadApps(field, any(), any(), any(), any()) } returns flowOf(listOf(app))
                 viewModel.init(
                     field,
-                    initialShowSystem = false,
+                    initialSystemAppsOnly = false,
                     initialShowArchived = false,
                     initialDescending = false,
                 )
@@ -781,7 +781,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -808,7 +808,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -831,7 +831,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.APK_SIZE,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -851,7 +851,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.APP_NAME,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -869,7 +869,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.PACKAGE_NAME,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -887,7 +887,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -906,7 +906,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -938,7 +938,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -956,7 +956,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -983,7 +983,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -998,7 +998,7 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = true,
                     descending = false,
                     reload = true,
@@ -1014,7 +1014,7 @@ class AppListViewModelTest {
 
             viewModel.init(
                 AppInfoField.VERSION,
-                initialShowSystem = false,
+                initialSystemAppsOnly = false,
                 initialShowArchived = false,
                 initialDescending = false,
             )
@@ -1029,7 +1029,7 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(
                     AppInfoField.ARCHIVED,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = true,
                     descending = false,
                     reload = false,

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppRepositoryTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppRepositoryTest.kt
@@ -189,7 +189,7 @@ class AppRepositoryTest {
             val flow =
                 repository.loadApps(
                     field = AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = false,
@@ -205,7 +205,7 @@ class AppRepositoryTest {
         }
 
     @Test
-    fun `given system apps, when loadApps called with showSystemApps false, filtered list is returned`() =
+    fun `given system apps, when loadApps called with systemAppsOnly false, filtered list is returned`() =
         runTest {
             val userApp = createApplicationInfo("com.test.userapp", isSystemApp = false)
             val systemApp = createApplicationInfo("com.android.system", isSystemApp = true)
@@ -220,7 +220,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -231,7 +231,7 @@ class AppRepositoryTest {
         }
 
     @Test
-    fun `given system apps, when loadApps called with showSystemApps true, system apps are included`() =
+    fun `given system apps, when loadApps called with systemAppsOnly true, only system apps are returned`() =
         runTest {
             val userApp = createApplicationInfo("com.test.userapp", isSystemApp = false)
             val systemApp = createApplicationInfo("com.android.system", isSystemApp = true)
@@ -246,13 +246,33 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = true,
+                        systemAppsOnly = true,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
                     ).first { it.isNotEmpty() }
 
-            assertEquals(2, result.size)
+            assertEquals(1, result.size)
+            assertEquals("com.android.system", result[0].packageName)
+        }
+
+    @Test
+    fun `given non-launchable user app, when user apps are selected, then it is filtered out`() =
+        runTest {
+            val app = createApp(packageName = "com.test.nonlaunchable").copy(hasLaunchIntent = false)
+            dbFlow.value = listOf(app.toCacheEntity(System.currentTimeMillis()))
+
+            val result =
+                repository
+                    .loadApps(
+                        field = AppInfoField.VERSION,
+                        systemAppsOnly = false,
+                        showArchivedApps = false,
+                        descending = false,
+                        reload = false,
+                    ).first()
+
+            assertTrue(result.isEmpty())
         }
 
     @Test
@@ -274,7 +294,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = true,
                         reload = false,
@@ -300,7 +320,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -326,7 +346,7 @@ class AppRepositoryTest {
             val flow =
                 repository.loadApps(
                     field = AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = false,
@@ -354,7 +374,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -381,7 +401,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -407,7 +427,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -425,7 +445,7 @@ class AppRepositoryTest {
     fun `given app with null package name, when loadApps called, then it handles it safely`() =
         runTest {
             val appInfo =
-                createApplicationInfo(null).apply {
+                createApplicationInfo(null, isSystemApp = true).apply {
                     metaData = Bundle().apply { putBoolean(AppStoreService.GOOGLE_PLAY_ARCHIVE_KEY, true) }
                 }
             every { packageService.getInstalledApplications(any<Long>()) } returns listOf(appInfo)
@@ -438,7 +458,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         field = AppInfoField.VERSION,
-                        showSystemApps = true,
+                        systemAppsOnly = true,
                         showArchivedApps = true,
                         descending = false,
                         reload = false,
@@ -453,7 +473,7 @@ class AppRepositoryTest {
     fun `given SDK 34, when loadApps called, then it uses isArchivedApp utility`() =
         runTest {
             val appInfo =
-                createApplicationInfo("com.test.archived").apply {
+                createApplicationInfo("com.test.archived", isSystemApp = true).apply {
                     metaData = Bundle().apply { putBoolean(AppStoreService.GOOGLE_PLAY_ARCHIVE_KEY, true) }
                 }
             every { packageService.getInstalledApplications(any<Long>()) } returns listOf(appInfo)
@@ -464,7 +484,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = true,
+                        systemAppsOnly = true,
                         showArchivedApps = true,
                         descending = false,
                         reload = false,
@@ -509,7 +529,7 @@ class AppRepositoryTest {
                 nullReporterRepository
                     .loadApps(
                         field = AppInfoField.TARGET_SDK,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = true,
@@ -531,7 +551,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -596,7 +616,7 @@ class AppRepositoryTest {
             repository
                 .loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = false,
@@ -619,7 +639,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -643,7 +663,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -667,7 +687,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -693,7 +713,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -725,7 +745,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = false,
                         descending = false,
                         reload = false,
@@ -749,7 +769,7 @@ class AppRepositoryTest {
                 repository
                     .loadApps(
                         AppInfoField.VERSION,
-                        showSystemApps = false,
+                        systemAppsOnly = false,
                         showArchivedApps = true,
                         descending = false,
                         reload = false,
@@ -907,7 +927,7 @@ class AppRepositoryTest {
             repository
                 .loadApps(
                     AppInfoField.VERSION,
-                    showSystemApps = false,
+                    systemAppsOnly = false,
                     showArchivedApps = false,
                     descending = false,
                     reload = false,

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/UiStateTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/UiStateTest.kt
@@ -11,7 +11,7 @@ class UiStateTest {
         val state = UiState()
 
         assertEquals(AppInfoField.VERSION, state.selectedField)
-        assertFalse(state.showSystem)
+        assertFalse(state.systemAppsOnly)
         assertFalse(state.descending)
         assertEquals("", state.query)
         assertFalse(state.isLoading)
@@ -28,12 +28,12 @@ class UiStateTest {
     }
 
     @Test
-    fun `given UiState, when copy with showSystem, then showSystem is updated`() {
+    fun `given UiState, when copy with systemAppsOnly, then systemAppsOnly is updated`() {
         val state = UiState()
 
-        val newState = state.copy(showSystem = true)
+        val newState = state.copy(systemAppsOnly = true)
 
-        assertTrue(newState.showSystem)
+        assertTrue(newState.systemAppsOnly)
     }
 
     @Test
@@ -88,7 +88,7 @@ class UiStateTest {
         val newState =
             state.copy(
                 selectedField = AppInfoField.MIN_SDK,
-                showSystem = true,
+                systemAppsOnly = true,
                 descending = true,
                 query = "search",
                 isLoading = true,
@@ -96,7 +96,7 @@ class UiStateTest {
             )
 
         assertEquals(AppInfoField.MIN_SDK, newState.selectedField)
-        assertTrue(newState.showSystem)
+        assertTrue(newState.systemAppsOnly)
         assertTrue(newState.descending)
         assertEquals("search", newState.query)
         assertTrue(newState.isLoading)


### PR DESCRIPTION
## Summary

Fixes the system-app filter toggle so the selected visibility mode is applied consistently across the UI, settings, repository, and view model.

## Impact

Users can reliably show or hide system apps, and the selection persists as expected.

## Validation

`./gradlew.bat test` reached `:app:testDebugUnitTest` but did not complete because Gradle could not find its transient `in-progress-results-generic.bin` result file.
