### PR TITLE
Export the current app view

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppExporter.kt
@@ -26,6 +26,7 @@ class AppExporter(
     registry: ActivityResultRegistry = activity.activityResultRegistry,
 ) {
     private var pendingExportFormat: ExportFormat? = null
+    private var pendingPackageNames: List<String>? = null
 
     private val exportLauncher =
         registry.register(
@@ -50,11 +51,13 @@ class AppExporter(
             uri?.let {
                 val format = pendingExportFormat ?: ExportFormat.XML
                 pendingExportFormat = null
-                writeToFile(it, format)
+                val packageNames = pendingPackageNames
+                pendingPackageNames = null
+                writeToFile(it, format, packageNames)
             }
         }
 
-    fun export() {
+    fun export(packageNames: List<String>? = null) {
         val view = activity.layoutInflater.inflate(R.layout.dialog_export_type, null)
         val radioGroup = view.findViewById<RadioGroup>(R.id.export_radio_group)
 
@@ -72,6 +75,7 @@ class AppExporter(
                         else -> ExportFormat.XML
                     }
                 pendingExportFormat = format
+                pendingPackageNames = packageNames
                 exportLauncher.launch(format)
             }.setNegativeButton(android.R.string.cancel, null)
             .show()
@@ -80,6 +84,7 @@ class AppExporter(
     internal fun writeToFile(
         uri: Uri,
         format: ExportFormat,
+        packageNames: List<String>? = null,
     ) {
         val includeUsageStats = shouldIncludeUsageStats()
         val loadingFailedValue = activity.getString(R.string.export_loading_failed)
@@ -87,7 +92,12 @@ class AppExporter(
             try {
                 // Force refresh cache to ensure export has fresh data
                 repository.refreshCache(force = true)
-                val apps = repository.getCachedApps()
+                val cachedApps = repository.getCachedApps()
+                val apps =
+                    packageNames?.let { names ->
+                        val appsByPackageName = cachedApps.associateBy { it.packageName }
+                        names.mapNotNull(appsByPackageName::get)
+                    } ?: cachedApps
                 exportToFile(uri, format) {
                     formatter.write(format, it, apps, includeUsageStats, loadingFailedValue)
                 }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -374,7 +374,7 @@ class MainActivity :
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.export -> {
-                appExporter.export()
+                appExporter.export(latestState.items.map { it.packageName })
                 return true
             }
 

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppExporterTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppExporterTest.kt
@@ -125,6 +125,45 @@ class AppExporterTest {
     }
 
     @Test
+    fun `writeToFile exports captured packages in captured order after refresh`() {
+        val refreshedApps =
+            listOf(
+                createTestApp("com.example.app1", "App 1 refreshed"),
+                createTestApp("com.example.app2", "App 2 refreshed"),
+                createTestApp("com.example.extra", "Extra"),
+            )
+        coEvery { repository.getCachedApps() } returns refreshedApps
+        val exporter =
+            AppExporter(
+                activity,
+                repository,
+                formatter,
+                appSettings,
+                crashReporter,
+                testDispatchers,
+                mockk<ActivityResultRegistry>(relaxed = true),
+            )
+        val file = File.createTempFile("apps", ".xml").apply { deleteOnExit() }
+
+        exporter.writeToFile(
+            Uri.fromFile(file),
+            ExportFormat.XML,
+            listOf("com.example.app2", "com.example.app1", "com.example.missing"),
+        )
+        Shadows.shadowOf(activity.mainLooper).idle()
+
+        verify {
+            formatter.write(
+                ExportFormat.XML,
+                any(),
+                listOf(refreshedApps[1], refreshedApps[0]),
+                true,
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun onActivityResult_withXml_exportsXml() {
         val registry = mockk<ActivityResultRegistry>(relaxed = true)
         val callbackSlot = slot<ActivityResultCallback<Uri?>>()


### PR DESCRIPTION
## Summary

Exports the apps visible when Export is tapped, preserving active search, filters, and display order.

## Why

Users can narrow the list before exporting without needing to export every installed app.

## Validation

- `./gradlew.bat testDebugUnitTest --tests "com.github.keeganwitt.applist.AppExporterTest" --tests "com.github.keeganwitt.applist.AppListViewModelTest"`
