### PR TITLE
build: Enable R8 optimization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,9 @@ android {
 
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            optimization {
+                enable = true
+            }
             ndk.debugSymbolLevel = "FULL"
         }
         getByName("debug") {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,0 @@
--dontobfuscate


### PR DESCRIPTION
## Summary

- Enable release code and resource optimization with the AGP 9.3 `optimization` DSL.
- Remove the obsolete `-dontobfuscate` rule so R8 can perform identifier minification.
- Preserve full NDK debug symbol generation.

## Bundle size

| Build | Bytes | MiB |
| --- | ---: | ---: |
| Before (`main`) | 7,400,996 | 7.058 |
| After (optimized) | 3,880,863 | 3.701 |
| Reduction | 3,520,133 | 3.357 |

The optimized bundle is **47.56% smaller**. R8 generated the expected mapping, usage, seeds, resource, and configuration-analysis outputs.

## Verification

- `./gradlew bundleRelease` — passed
- `./gradlew test --rerun-tasks :app:ktlintKotlinScriptCheck` — passed
- `createDebugUnitTestCoverageReport` — completed successfully
- `ktlintCheck` still reports pre-existing violations in `MainActivityTest.kt`; the same failure was reproduced on unchanged `main`.