### PR TITLE
Recognize Obtainium installer

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/services/AppStoreService.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/services/AppStoreService.kt
@@ -48,6 +48,7 @@ interface AppStoreService {
         const val F_DROID = "org.fdroid.fdroid"
         const val DROIDIFY = "com.looker.droidify"
         const val NEO_STORE = "com.machaiv3lli.fdroid"
+        const val OBTAINIUM = "dev.imranr.obtainium"
         const val GOOGLE_PLAY_ARCHIVE_KEY = "com.android.vending.archive"
     }
 }
@@ -159,6 +160,7 @@ open class DefaultAppStoreService(
                 AppStoreService.VIVO_APP_STORE to "Vivo App Store",
                 AppStoreService.DROIDIFY to "Droid-ify",
                 AppStoreService.NEO_STORE to "Neo Store",
+                AppStoreService.OBTAINIUM to "Obtainium",
             )
     }
 }

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/services/AppStoreServiceTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/services/AppStoreServiceTest.kt
@@ -229,6 +229,7 @@ class AppStoreServiceTest {
                 AppStoreService.VIVO_APP_STORE to "Vivo App Store",
                 AppStoreService.DROIDIFY to "Droid-ify",
                 AppStoreService.NEO_STORE to "Neo Store",
+                AppStoreService.OBTAINIUM to "Obtainium",
             )
 
         installers.forEach { (pkg, name) ->


### PR DESCRIPTION
## Summary
- recognize Obtainium as a known installer
- display Obtainium instead of the unknown installer fallback
- cover the display name in AppStoreService tests

## Testing
- .\\gradlew.bat :app:testDebugUnitTest