### PR TITLE
Fix export activity loading and status bar contrast

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,12 @@ kotlin {
     jvmToolchain(21)
 }
 
+val jacocoToolVersion = "0.8.14"
+
+jacoco {
+    toolVersion = jacocoToolVersion
+}
+
 android {
     namespace = "com.github.keeganwitt.applist"
 
@@ -45,7 +51,7 @@ android {
     }
 
     testCoverage {
-        jacocoVersion = "0.8.12"
+        jacocoVersion = jacocoToolVersion
     }
 
     compileOptions {

--- a/app/src/androidTest/kotlin/com/github/keeganwitt/applist/ExportActivityTest.kt
+++ b/app/src/androidTest/kotlin/com/github/keeganwitt/applist/ExportActivityTest.kt
@@ -1,5 +1,7 @@
 package com.github.keeganwitt.applist
 
+import android.content.res.Configuration
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.test.core.app.ActivityScenario
@@ -36,6 +38,20 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class ExportActivityTest {
+    @Test
+    fun statusBarIconsContrastWithTheCurrentTheme() {
+        ActivityScenario.launch(ExportActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val isLightMode =
+                    activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
+                        Configuration.UI_MODE_NIGHT_YES
+                val controller = WindowCompat.getInsetsController(activity.window, activity.window.decorView)
+
+                assertEquals(isLightMode, controller.isAppearanceLightStatusBars)
+            }
+        }
+    }
+
     @Test
     fun searchFieldFiltersImmediatelyClearsAndSurvivesRecreation() {
         ActivityScenario.launch(ExportActivity::class.java).use { scenario ->

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -3,6 +3,7 @@ package com.github.keeganwitt.applist
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,14 +87,31 @@ class AppListViewModel(
         loadApps(reload = true)
     }
 
-    private var loadJob: kotlinx.coroutines.Job? = null
+    private var loadJob: Job? = null
+    private var summaryJob: Job? = null
+    private var cachedLoadOptions: LoadOptions? = null
     private var loadRequestId = 0L
 
     private fun loadApps(reload: Boolean) {
         val requestId = ++loadRequestId
         loadJob?.cancel()
+        summaryJob?.cancel()
         val state = _uiState.value
-        _uiState.update { it.copy(isLoading = true, loadFailed = false, isFullyLoaded = false, summary = null) }
+        val options =
+            LoadOptions(
+                state.selectedField,
+                state.systemAppsOnly,
+                state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
+                state.descending,
+            )
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                loadFailed = false,
+                isFullyLoaded = false,
+                summary = null,
+            )
+        }
 
         loadJob =
             viewModelScope.launch(dispatchers.io) {
@@ -101,10 +119,10 @@ class AppListViewModel(
                     loadMutex.withLock {
                         repository
                             .loadApps(
-                                field = state.selectedField,
-                                systemAppsOnly = state.systemAppsOnly,
-                                showArchivedApps = state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
-                                descending = state.descending,
+                                field = options.field,
+                                systemAppsOnly = options.systemAppsOnly,
+                                showArchivedApps = options.showArchivedApps,
+                                descending = options.descending,
                                 reload = reload,
                             ).collect { apps ->
                                 withContext(dispatchers.main) {
@@ -112,6 +130,7 @@ class AppListViewModel(
                                     val field = _uiState.value.selectedField
                                     cachedMappedItems = apps.map { mapToItem(it, field) }
                                     cachedMappedItemsField = field
+                                    cachedLoadOptions = options
                                     val fullyLoaded = apps.isEmpty() || apps.all { it.isDetailed }
                                     _uiState.update {
                                         it.copy(isLoading = false, loadFailed = false, isFullyLoaded = fullyLoaded)
@@ -124,8 +143,23 @@ class AppListViewModel(
                     if (exception is CancellationException) throw exception
                     withContext(dispatchers.main) {
                         if (requestId != loadRequestId) return@withContext
+                        val discardResults = options != cachedLoadOptions || options.field != cachedMappedItemsField
+                        if (discardResults) {
+                            summaryJob?.cancel()
+                            allApps = emptyList()
+                            cachedMappedItems = null
+                            cachedMappedItemsField = null
+                            cachedLoadOptions = null
+                        }
                         _uiState.update {
-                            it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                            it.copy(
+                                isLoading = false,
+                                loadFailed = true,
+                                isFullyLoaded = false,
+                                items = if (discardResults) emptyList() else it.items,
+                                filteredApps = if (discardResults) emptyList() else it.filteredApps,
+                                summary = null,
+                            )
                         }
                     }
                 }
@@ -133,7 +167,9 @@ class AppListViewModel(
     }
 
     private fun applyFilterAndEmit() {
+        summaryJob?.cancel()
         val state = _uiState.value
+        val apps = allApps
         if (cachedMappedItems == null || cachedMappedItemsField != state.selectedField) {
             cachedMappedItems = allApps.map { mapToItem(it, state.selectedField) }
             cachedMappedItemsField = state.selectedField
@@ -151,26 +187,27 @@ class AppListViewModel(
             }
         _uiState.update { it.copy(items = filtered) }
 
-        viewModelScope.launch(dispatchers.default) {
-            val filteredApps =
-                if (state.query.isBlank()) {
-                    allApps
-                } else {
-                    val filteredPackageNames = filtered.map { it.packageName }.toSet()
-                    allApps.filter { app -> app.packageName in filteredPackageNames }
-                }
+        summaryJob =
+            viewModelScope.launch(dispatchers.default) {
+                val filteredApps =
+                    if (state.query.isBlank()) {
+                        apps
+                    } else {
+                        val filteredPackageNames = filtered.map { it.packageName }.toSet()
+                        apps.filter { app -> app.packageName in filteredPackageNames }
+                    }
 
-            if (state.isFullyLoaded) {
-                val summary = summaryCalculator.calculate(filteredApps, state.selectedField)
-                withContext(dispatchers.main) {
-                    _uiState.update { it.copy(summary = summary, filteredApps = filteredApps) }
-                }
-            } else {
-                withContext(dispatchers.main) {
-                    _uiState.update { it.copy(summary = null, filteredApps = filteredApps) }
+                if (state.isFullyLoaded) {
+                    val summary = summaryCalculator.calculate(filteredApps, state.selectedField)
+                    withContext(dispatchers.main) {
+                        _uiState.update { it.copy(summary = summary, filteredApps = filteredApps) }
+                    }
+                } else {
+                    withContext(dispatchers.main) {
+                        _uiState.update { it.copy(summary = null, filteredApps = filteredApps) }
+                    }
                 }
             }
-        }
     }
 
     private fun mapToItem(
@@ -199,4 +236,11 @@ class AppListViewModel(
             isLoading = !app.isDetailed,
         )
     }
+
+    private data class LoadOptions(
+        val field: AppInfoField,
+        val systemAppsOnly: Boolean,
+        val showArchivedApps: Boolean,
+        val descending: Boolean,
+    )
 }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -87,8 +87,10 @@ class AppListViewModel(
     }
 
     private var loadJob: kotlinx.coroutines.Job? = null
+    private var loadRequestId = 0L
 
     private fun loadApps(reload: Boolean) {
+        val requestId = ++loadRequestId
         loadJob?.cancel()
         val state = _uiState.value
         _uiState.update { it.copy(isLoading = true, loadFailed = false, isFullyLoaded = false, summary = null) }
@@ -120,8 +122,11 @@ class AppListViewModel(
                     }
                 } catch (exception: Exception) {
                     if (exception is CancellationException) throw exception
-                    _uiState.update {
-                        it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                    withContext(dispatchers.main) {
+                        if (requestId != loadRequestId) return@withContext
+                        _uiState.update {
+                            it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -2,11 +2,14 @@ package com.github.keeganwitt.applist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 class AppListViewModel(
@@ -31,6 +34,7 @@ class AppListViewModel(
     private var allApps: List<App> = emptyList()
     private var cachedMappedItems: List<AppItemUiModel>? = null
     private var cachedMappedItemsField: AppInfoField? = null
+    private val loadMutex = Mutex()
 
     fun init(
         initialField: AppInfoField,
@@ -87,28 +91,39 @@ class AppListViewModel(
     private fun loadApps(reload: Boolean) {
         loadJob?.cancel()
         val state = _uiState.value
-        _uiState.update { it.copy(isLoading = true, isFullyLoaded = false, summary = null) }
+        _uiState.update { it.copy(isLoading = true, loadFailed = false, isFullyLoaded = false, summary = null) }
 
         loadJob =
             viewModelScope.launch(dispatchers.io) {
-                repository
-                    .loadApps(
-                        field = state.selectedField,
-                        systemAppsOnly = state.systemAppsOnly,
-                        showArchivedApps = state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
-                        descending = state.descending,
-                        reload = reload,
-                    ).collect { apps ->
-                        withContext(dispatchers.main) {
-                            allApps = apps
-                            val field = _uiState.value.selectedField
-                            cachedMappedItems = apps.map { mapToItem(it, field) }
-                            cachedMappedItemsField = field
-                            val fullyLoaded = apps.isEmpty() || apps.all { it.isDetailed }
-                            _uiState.update { it.copy(isLoading = false, isFullyLoaded = fullyLoaded) }
-                            applyFilterAndEmit()
-                        }
+                try {
+                    loadMutex.withLock {
+                        repository
+                            .loadApps(
+                                field = state.selectedField,
+                                systemAppsOnly = state.systemAppsOnly,
+                                showArchivedApps = state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
+                                descending = state.descending,
+                                reload = reload,
+                            ).collect { apps ->
+                                withContext(dispatchers.main) {
+                                    allApps = apps
+                                    val field = _uiState.value.selectedField
+                                    cachedMappedItems = apps.map { mapToItem(it, field) }
+                                    cachedMappedItemsField = field
+                                    val fullyLoaded = apps.isEmpty() || apps.all { it.isDetailed }
+                                    _uiState.update {
+                                        it.copy(isLoading = false, loadFailed = false, isFullyLoaded = fullyLoaded)
+                                    }
+                                    applyFilterAndEmit()
+                                }
+                            }
                     }
+                } catch (exception: Exception) {
+                    if (exception is CancellationException) throw exception
+                    _uiState.update {
+                        it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                    }
+                }
             }
     }
 

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -48,6 +49,8 @@ interface AppRepository {
 
     fun getSyncState(): Flow<SyncState>
 
+    fun observeCachedApps(): Flow<List<App>>
+
     suspend fun refreshCache(force: Boolean = false)
 
     suspend fun getCachedApps(): List<App>
@@ -65,6 +68,8 @@ class AndroidAppRepository(
     private val syncMutex = Mutex()
 
     override fun getSyncState(): Flow<SyncState> = _syncState.asStateFlow()
+
+    override fun observeCachedApps() = appDao.getAllAppsFlow().map { entities -> entities.map { it.toDomainModel() } }
 
     override fun loadApps(
         field: AppInfoField,

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppRepository.kt
@@ -180,6 +180,7 @@ class AndroidAppRepository(
                 if (isInitial) _syncState.value = SyncState.BuildingInitial(0, toSync.size)
 
                 val lastUsedEpochs = usageStatsService.getLastUsedEpochs(force)
+                val initialApps = mutableListOf<AppCacheEntity>()
 
                 var processedCount = 0
                 toSync.chunked(10).forEach { chunk ->
@@ -192,7 +193,12 @@ class AndroidAppRepository(
                                         mapToAppDetailed(ai, basic, lastUsedEpochs)
                                     }
                                 }.awaitAll()
-                        appDao.insertApps(apps.map { it.toCacheEntity(System.currentTimeMillis()) })
+                        val cacheEntities = apps.map { it.toCacheEntity(System.currentTimeMillis()) }
+                        if (isInitial) {
+                            initialApps.addAll(cacheEntities)
+                        } else {
+                            appDao.insertApps(cacheEntities)
+                        }
                     }
                     processedCount += chunk.size
 
@@ -200,6 +206,7 @@ class AndroidAppRepository(
                         _syncState.value = SyncState.BuildingInitial(processedCount, toSync.size)
                     }
                 }
+                if (isInitial) appDao.insertApps(initialApps)
             }
         } finally {
             _syncState.value = SyncState.Idle

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/ExportActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/ExportActivity.kt
@@ -1,11 +1,14 @@
 package com.github.keeganwitt.applist
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.activity.addCallback
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
@@ -28,8 +31,15 @@ internal class ExportActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = ActivityExportBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
+        val isLightMode =
+            resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
+                Configuration.UI_MODE_NIGHT_YES
+        windowInsetsController.isAppearanceLightStatusBars = isLightMode
 
         setupViewModel()
         setupExporter()

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/ExportViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/ExportViewModel.kt
@@ -3,11 +3,15 @@ package com.github.keeganwitt.applist
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 internal class ExportViewModel(
     val repository: AppRepository,
@@ -20,6 +24,8 @@ internal class ExportViewModel(
 
     private var allApps: List<App> = emptyList()
     private var selectedPackageNames: Set<String> = emptySet()
+    private var hasInitializedSelection = false
+    private var cacheObservationJob: Job? = null
     private var pendingExportRequest: ExportRequest? = null
     private var exportWriteStarted = false
     private val _exportCompletion = MutableStateFlow<ExportCompletion?>(null)
@@ -31,23 +37,43 @@ internal class ExportViewModel(
 
     fun refresh() {
         _uiState.update { it.copy(isLoading = true, loadFailed = false) }
-        viewModelScope.launch(dispatchers.io) {
-            try {
-                var cachedApps = repository.getCachedApps()
-                if (cachedApps.isEmpty()) {
-                    repository.refreshCache(force = true)
-                    cachedApps = repository.getCachedApps()
+        cacheObservationJob?.cancel()
+        cacheObservationJob =
+            viewModelScope.launch(dispatchers.io) {
+                try {
+                    var cachedApps = repository.getCachedApps()
+                    if (cachedApps.isEmpty()) {
+                        repository.refreshCache(force = true)
+                        cachedApps = repository.getCachedApps()
+                    }
+                    applyCacheUpdate(cachedApps)
+                    repository.observeCachedApps().collect(::applyCacheUpdate)
+                } catch (exception: Exception) {
+                    if (exception is CancellationException) throw exception
+                    _uiState.update { it.copy(isLoading = false, loadFailed = true) }
                 }
-                allApps = cachedApps.sortedWith(appComparator)
-                selectedPackageNames =
-                    allApps
-                        .filter { it.isUserInstalled && it.archived != true }
-                        .mapTo(mutableSetOf()) { it.packageName }
-                emitState()
-            } catch (_: Exception) {
-                _uiState.update { it.copy(isLoading = false, loadFailed = true) }
             }
+    }
+
+    private suspend fun applyCacheUpdate(apps: List<App>) {
+        withContext(dispatchers.main) {
+            updateApps(apps)
         }
+    }
+
+    private fun updateApps(apps: List<App>) {
+        allApps = apps.sortedWith(appComparator)
+        val availablePackageNames = allApps.mapTo(mutableSetOf()) { it.packageName }
+        selectedPackageNames =
+            if (hasInitializedSelection) {
+                selectedPackageNames.intersect(availablePackageNames)
+            } else {
+                allApps
+                    .filter { it.isUserInstalled && it.archived != true }
+                    .mapTo(mutableSetOf()) { it.packageName }
+            }
+        hasInitializedSelection = true
+        emitState()
     }
 
     fun setShowArchived(showArchived: Boolean) {

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/ExportViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/ExportViewModel.kt
@@ -33,8 +33,12 @@ internal class ExportViewModel(
         _uiState.update { it.copy(isLoading = true, loadFailed = false) }
         viewModelScope.launch(dispatchers.io) {
             try {
-                repository.refreshCache(force = true)
-                allApps = repository.getCachedApps().sortedWith(appComparator)
+                var cachedApps = repository.getCachedApps()
+                if (cachedApps.isEmpty()) {
+                    repository.refreshCache(force = true)
+                    cachedApps = repository.getCachedApps()
+                }
+                allApps = cachedApps.sortedWith(appComparator)
                 selectedPackageNames =
                     allApps
                         .filter { it.isUserInstalled && it.archived != true }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/ExportViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/ExportViewModel.kt
@@ -36,13 +36,14 @@ internal class ExportViewModel(
     }
 
     fun refresh() {
+        val isRetry = _uiState.value.loadFailed
         _uiState.update { it.copy(isLoading = true, loadFailed = false) }
         cacheObservationJob?.cancel()
         cacheObservationJob =
             viewModelScope.launch(dispatchers.io) {
                 try {
                     var cachedApps = repository.getCachedApps()
-                    if (cachedApps.isEmpty()) {
+                    if (isRetry || cachedApps.isEmpty()) {
                         repository.refreshCache(force = true)
                         cachedApps = repository.getCachedApps()
                     }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -29,6 +29,7 @@ import com.github.keeganwitt.applist.databinding.ActivityMainBinding
 import com.github.keeganwitt.applist.services.DefaultAppStoreService
 import com.github.keeganwitt.applist.utils.PermissionUtils
 import com.github.keeganwitt.applist.utils.nightMode
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.text.Collator
@@ -45,6 +46,7 @@ class MainActivity :
     private lateinit var fieldToLabelMap: Map<AppInfoField, String>
     private lateinit var appSettings: AppSettings
     private var latestState: UiState = UiState()
+    private var loadFailureSnackbar: Snackbar? = null
     private var shouldRefreshOnResume = false
     private var ignoreQueryChanges = false
     private var pendingField: AppInfoField? = null
@@ -194,9 +196,25 @@ class MainActivity :
                         ignoreQueryChanges = true
                         invalidateOptionsMenu()
                     }
+                    updateLoadFailureUi(state.loadFailed)
                     updateSyncUi(state.syncState)
                 }
             }
+        }
+    }
+
+    private fun updateLoadFailureUi(loadFailed: Boolean) {
+        if (loadFailed) {
+            if (loadFailureSnackbar?.isShown != true) {
+                loadFailureSnackbar =
+                    Snackbar
+                        .make(binding.root, R.string.loading_failed, Snackbar.LENGTH_INDEFINITE)
+                        .setAction(R.string.export_retry) { appListViewModel.refresh() }
+                        .also(Snackbar::show)
+            }
+        } else {
+            loadFailureSnackbar?.dismiss()
+            loadFailureSnackbar = null
         }
     }
 

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/UiState.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/UiState.kt
@@ -7,6 +7,7 @@ data class UiState(
     val descending: Boolean = false,
     val query: String = "",
     val isLoading: Boolean = false,
+    val loadFailed: Boolean = false,
     val isFullyLoaded: Boolean = false,
     val items: List<AppItemUiModel> = emptyList(),
     val filteredApps: List<App> = emptyList(),

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
@@ -996,6 +997,214 @@ class AppListViewModelTest {
             assertFalse(state.isFullyLoaded)
             assertTrue(state.loadFailed)
             assertTrue(state.items.isEmpty())
+        }
+
+    @Test
+    fun `given cached apps, when changed options fail before emitting, then old results are cleared`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            val changes =
+                listOf<Pair<String, () -> Unit>>(
+                    "field" to { viewModel.updateSelectedField(AppInfoField.ENABLED) },
+                    "sort" to { viewModel.setDescending(true) },
+                    "system apps" to { viewModel.setSystemAppsOnly(true) },
+                    "archived apps" to { viewModel.setShowArchived(true) },
+                    "initial options" to { viewModel.init(AppInfoField.ARCHIVED, true, true, true) },
+                )
+
+            for ((name, change) in changes) {
+                coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(cachedApp))
+                viewModel.init(AppInfoField.VERSION, false, false, false)
+                advanceUntilIdle()
+                assertEquals(
+                    listOf("1.2.3"),
+                    viewModel.uiState.value.items
+                        .map { it.infoText },
+                )
+
+                coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                    flow { throw IllegalStateException("replacement failed") }
+                change()
+                advanceUntilIdle()
+
+                val state = viewModel.uiState.value
+                assertTrue(name, state.loadFailed)
+                assertFalse(name, state.isLoading)
+                assertTrue(name, state.items.isEmpty())
+                assertTrue(name, state.filteredApps.isEmpty())
+                assertNull(name, state.summary)
+
+                viewModel.setQuery("Cached")
+                advanceUntilIdle()
+                assertTrue(
+                    name,
+                    viewModel.uiState.value.items
+                        .isEmpty(),
+                )
+                assertTrue(
+                    name,
+                    viewModel.uiState.value.filteredApps
+                        .isEmpty(),
+                )
+                viewModel.setQuery("")
+                advanceUntilIdle()
+                assertTrue(
+                    name,
+                    viewModel.uiState.value.items
+                        .isEmpty(),
+                )
+            }
+        }
+
+    @Test
+    fun `given field change still loading, when refresh replaces it and fails, then original rows are cleared`() =
+        runTest {
+            val app = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flow { awaitCancellation() }
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement refresh failed") }
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertEquals(AppInfoField.ENABLED, viewModel.uiState.value.selectedField)
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertTrue(
+                viewModel.uiState.value.items
+                    .isEmpty(),
+            )
+            assertTrue(
+                viewModel.uiState.value.filteredApps
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `given cached rows remapped during loading, when returning to original field fails, then remapped rows are cleared`() =
+        runTest {
+            val app = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flow { awaitCancellation() }
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+            viewModel.setQuery("Cached")
+            advanceUntilIdle()
+            assertEquals(
+                listOf("true"),
+                viewModel.uiState.value.items
+                    .map { it.infoText },
+            )
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement failed") }
+            viewModel.updateSelectedField(AppInfoField.VERSION)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(AppInfoField.VERSION, state.selectedField)
+            assertTrue(state.loadFailed)
+            assertTrue(state.items.isEmpty())
+            assertTrue(state.filteredApps.isEmpty())
+        }
+
+    @Test
+    fun `given cached apps, when unchanged refresh fails before emitting, then cached results remain`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(cachedApp))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+            val cachedItems = viewModel.uiState.value.items
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("refresh failed") }
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertEquals(cachedItems, viewModel.uiState.value.items)
+            assertEquals(listOf(cachedApp), viewModel.uiState.value.filteredApps)
+        }
+
+    @Test
+    fun `given changed field failed, when retry emits then fails, then only replacement results remain`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            val replacementApp = createTestApp("com.replacement.app", "Replacement App")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(cachedApp))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement failed") }
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            advanceUntilIdle()
+            assertEquals(AppInfoField.ENABLED, viewModel.uiState.value.selectedField)
+            assertTrue(
+                viewModel.uiState.value.items
+                    .isEmpty(),
+            )
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow {
+                    emit(listOf(replacementApp))
+                    throw IllegalStateException("sync failed")
+                }
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertEquals(
+                listOf("com.replacement.app"),
+                viewModel.uiState.value.items
+                    .map { it.packageName },
+            )
+            assertEquals(
+                listOf("true"),
+                viewModel.uiState.value.items
+                    .map { it.infoText },
+            )
+        }
+
+    @Test
+    fun `given pending summary, when option change fails, then stale summary cannot restore cleared results`() =
+        runTest {
+            val summaryScheduler = TestCoroutineScheduler()
+            val provider =
+                object : DispatcherProvider {
+                    override val io = testDispatcher
+                    override val main = testDispatcher
+                    override val default = StandardTestDispatcher(summaryScheduler)
+                }
+            viewModel = AppListViewModel(repository, provider, summaryCalculator, { it.toString() }, "Unknown", "Failed")
+            val app = createTestApp("com.cached.app", "Cached App", isDetailed = true)
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            runCurrent()
+            assertEquals(1, viewModel.uiState.value.items.size)
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement failed") }
+            viewModel.setDescending(true)
+            runCurrent()
+            summaryScheduler.runCurrent()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertNull(viewModel.uiState.value.summary)
+            assertTrue(
+                viewModel.uiState.value.filteredApps
+                    .isEmpty(),
+            )
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -995,6 +996,49 @@ class AppListViewModelTest {
             assertFalse(state.isFullyLoaded)
             assertTrue(state.loadFailed)
             assertTrue(state.items.isEmpty())
+        }
+
+    @Test
+    fun `given canceled producer throws, when replacement awaits results, then loading state belongs to replacement`() =
+        runTest {
+            val replacementResult = CompletableDeferred<List<App>>()
+            var loadCount = 0
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } answers {
+                loadCount++
+                if (loadCount == 1) {
+                    channelFlow {
+                        try {
+                            awaitCancellation()
+                        } finally {
+                            throw IllegalStateException("canceled producer failed")
+                        }
+                    }
+                } else {
+                    flow { emit(replacementResult.await()) }
+                }
+            }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            runCurrent()
+
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+            val pendingState = viewModel.uiState.value
+
+            replacementResult.complete(listOf(createTestApp("com.replacement.app", "Replacement")))
+            advanceUntilIdle()
+
+            assertEquals(2, loadCount)
+            assertTrue(pendingState.isLoading)
+            assertFalse(pendingState.loadFailed)
+            val completedState = viewModel.uiState.value
+            assertFalse(completedState.loadFailed)
+            assertEquals(listOf("com.replacement.app"), completedState.items.map { it.packageName })
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -5,8 +5,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -14,6 +18,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -969,6 +974,100 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(any(), any(), any(), any(), any())
             }
+        }
+
+    @Test
+    fun `given load fails before emitting apps, when initialized, then failure is exposed`() =
+        runTest {
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("load failed") }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isLoading)
+            assertFalse(state.isFullyLoaded)
+            assertTrue(state.loadFailed)
+            assertTrue(state.items.isEmpty())
+        }
+
+    @Test
+    fun `given load fails after emitting cached apps, when initialized, then apps remain visible with failure`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow {
+                    emit(listOf(cachedApp))
+                    throw IllegalStateException("refresh failed")
+                }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isLoading)
+            assertFalse(state.isFullyLoaded)
+            assertTrue(state.loadFailed)
+            assertEquals(listOf("com.cached.app"), state.items.map { it.packageName })
+        }
+
+    @Test
+    fun `given canceled load is still cleaning up, when load is replaced, then replacement waits`() =
+        runTest {
+            val cleanupStarted = CompletableDeferred<Unit>()
+            val allowCleanup = CompletableDeferred<Unit>()
+            val replacementStarted = CompletableDeferred<Unit>()
+            var loadCount = 0
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } answers {
+                loadCount++
+                if (loadCount == 1) {
+                    flow {
+                        try {
+                            awaitCancellation()
+                        } finally {
+                            withContext(NonCancellable) {
+                                cleanupStarted.complete(Unit)
+                                allowCleanup.await()
+                            }
+                        }
+                    }
+                } else {
+                    flow {
+                        replacementStarted.complete(Unit)
+                        emit(emptyList())
+                    }
+                }
+            }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            runCurrent()
+
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+
+            assertTrue(cleanupStarted.isCompleted)
+            assertFalse(replacementStarted.isCompleted)
+
+            allowCleanup.complete(Unit)
+            advanceUntilIdle()
+
+            assertTrue(replacementStarted.isCompleted)
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppRepositoryTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppRepositoryTest.kt
@@ -19,6 +19,8 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -171,6 +173,21 @@ class AppRepositoryTest {
             assertEquals(2, result.size)
             assertEquals("pkg1", result[0].packageName)
             assertEquals("pkg2", result[1].packageName)
+        }
+
+    @Test
+    fun `observeCachedApps maps subsequent database updates`() =
+        runTest {
+            dbFlow.value = listOf(createAppEntity("initial.app"))
+            val emissions = mutableListOf<List<App>>()
+            val collection = launch { repository.observeCachedApps().take(2).toList(emissions) }
+            runCurrent()
+
+            dbFlow.value = listOf(createAppEntity("updated.app"))
+            collection.join()
+
+            assertEquals(listOf("initial.app"), emissions[0].map { it.packageName })
+            assertEquals(listOf("updated.app"), emissions[1].map { it.packageName })
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppRepositoryTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppRepositoryTest.kt
@@ -17,6 +17,8 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
@@ -28,6 +30,7 @@ import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -159,6 +162,75 @@ class AppRepositoryTest {
             assertTrue(states.any { it is SyncState.BuildingInitial })
             assertTrue(states.last() is SyncState.Idle)
             job.cancel()
+        }
+
+    @Test
+    fun `failed initial sync does not write completed chunks`() =
+        runTest {
+            val installedApps = (1..11).map { createApplicationInfo("com.test.app$it") }
+            every { packageService.getInstalledApplications(any<Long>()) } returns installedApps
+            every { packageService.getLaunchablePackages() } returns installedApps.mapNotNull { it.packageName }.toSet()
+            every { packageService.getPackageInfo(any<ApplicationInfo>()) } returns createPackageInfo("1.0")
+            every { packageService.loadLabel(any<ApplicationInfo>()) } answers {
+                val packageName = firstArg<ApplicationInfo>().packageName
+                if (packageName == "com.test.app11") throw IllegalStateException("load failed")
+                packageName
+            }
+            every { usageStatsService.getLastUsedEpochs(any<Boolean>()) } returns emptyMap()
+            every { storageService.getStorageUsage(any<ApplicationInfo>()) } returns StorageUsage()
+
+            try {
+                repository.refreshCache()
+                fail("Expected initial sync to fail")
+            } catch (_: IllegalStateException) {
+            }
+
+            assertTrue(dbFlow.value.isEmpty())
+            coVerify(exactly = 0) { appDao.insertApps(any()) }
+        }
+
+    @Test
+    fun `cancelled initial sync does not expose a partial cache`() =
+        runTest {
+            val installedApps = (1..11).map { createApplicationInfo("com.test.app$it") }
+            every { packageService.getInstalledApplications(any<Long>()) } returns installedApps
+            every { packageService.getLaunchablePackages() } returns installedApps.mapNotNull { it.packageName }.toSet()
+            every { packageService.getPackageInfo(any<ApplicationInfo>()) } returns createPackageInfo("1.0")
+            every { packageService.loadLabel(any<ApplicationInfo>()) } returns "App"
+            every { usageStatsService.getLastUsedEpochs(any<Boolean>()) } returns emptyMap()
+            every { storageService.getStorageUsage(any<ApplicationInfo>()) } returns StorageUsage()
+
+            coEvery { appDao.insertApps(any()) } coAnswers {
+                awaitCancellation()
+            }
+            val refreshJob = launch { repository.refreshCache() }
+            runCurrent()
+
+            refreshJob.cancelAndJoin()
+
+            assertTrue(dbFlow.value.isEmpty())
+            coVerify(exactly = 1) { appDao.insertApps(match { it.size == 11 }) }
+        }
+
+    @Test
+    fun `cancelled background sync preserves the existing cache`() =
+        runTest {
+            val cachedApp = createAppEntity("com.test.app")
+            dbFlow.value = listOf(cachedApp)
+            val installedApp = createApplicationInfo("com.test.app")
+            every { packageService.getInstalledApplications(any<Long>()) } returns listOf(installedApp)
+            every { packageService.getLaunchablePackages() } returns setOf("com.test.app")
+            every { packageService.getPackageInfo(any<ApplicationInfo>()) } returns createPackageInfo("1.0")
+            every { packageService.loadLabel(any<ApplicationInfo>()) } returns "App"
+            every { usageStatsService.getLastUsedEpochs(any<Boolean>()) } returns emptyMap()
+            every { storageService.getStorageUsage(any<ApplicationInfo>()) } returns StorageUsage()
+            coEvery { appDao.insertApps(any()) } coAnswers { awaitCancellation() }
+            val refreshJob = launch { repository.refreshCache(force = true) }
+            runCurrent()
+
+            refreshJob.cancelAndJoin()
+
+            assertEquals(listOf(cachedApp), dbFlow.value)
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/ExportLifecycleTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/ExportLifecycleTest.kt
@@ -164,6 +164,8 @@ class ExportLifecycleTest {
 
         override fun getSyncState(): Flow<SyncState> = flowOf(SyncState.Idle)
 
+        override fun observeCachedApps(): Flow<List<App>> = flowOf(listOf(app))
+
         override suspend fun refreshCache(force: Boolean) = Unit
 
         override suspend fun getCachedApps(): List<App> = listOf(app)

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/ExportViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/ExportViewModelTest.kt
@@ -3,12 +3,17 @@ package com.github.keeganwitt.applist
 import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -318,6 +323,53 @@ class ExportViewModelTest {
         }
 
     @Test
+    fun `retry force refreshes a partial cache left by a failed initial sync`() =
+        runTest(dispatcher) {
+            var attempts = 0
+            repository.refreshBlock = {
+                attempts++
+                if (attempts == 1) {
+                    repository.apps = listOf(app("partial.app", "Partial"))
+                    throw IllegalStateException("sync failed")
+                }
+                repository.apps = listOf(app("complete.app", "Complete"))
+            }
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertEquals(listOf(true), repository.refreshForces)
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.loadFailed)
+            assertEquals(listOf(true, true), repository.refreshForces)
+            assertEquals(listOf("complete.app"), viewModel.appsForExport().map { it.packageName })
+        }
+
+    @Test
+    fun `refresh replaces active observation without exposing cancellation as failure`() =
+        runTest(dispatcher) {
+            repository.apps = listOf(app("user.app", "User"))
+            val ioDispatcher = StandardTestDispatcher(testScheduler)
+            val mainDispatcher = StandardTestDispatcher(testScheduler)
+            viewModel = createViewModel(ioDispatcher = ioDispatcher, mainDispatcher = mainDispatcher)
+            val loadFailures = mutableListOf<Boolean>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.map { it.loadFailed }.toList(loadFailures)
+            }
+            advanceUntilIdle()
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertFalse(loadFailures.any { it })
+            assertFalse(viewModel.uiState.value.loadFailed)
+            assertEquals(listOf("user.app"), viewModel.appsForExport().map { it.packageName })
+        }
+
+    @Test
     fun `export request captures format and order while controls remain frozen`() =
         runTest(dispatcher) {
             repository.apps = listOf(app("zulu", "Zulu"), app("alpha", "Alpha"))
@@ -451,14 +503,16 @@ class ExportViewModelTest {
 
     private fun createViewModel(
         exportFileWriter: ExportFileWriter = ExportFileWriter { _, _ -> ExportCompletion(ExportOutcome.SUCCESS) },
+        ioDispatcher: CoroutineDispatcher = dispatcher,
+        mainDispatcher: CoroutineDispatcher = dispatcher,
     ): ExportViewModel =
         ExportViewModel(
             repository = repository,
             dispatchers =
                 object : DispatcherProvider {
-                    override val io = dispatcher
-                    override val main = dispatcher
-                    override val default = dispatcher
+                    override val io = ioDispatcher
+                    override val main = mainDispatcher
+                    override val default = ioDispatcher
                 },
             appComparator = compareBy<App> { it.name }.thenBy { it.packageName },
             exportFileWriter = exportFileWriter,
@@ -513,6 +567,7 @@ class ExportViewModelTest {
                 appsFlow.value = value
             }
         var refreshError: Exception? = null
+        var refreshBlock: (() -> Unit)? = null
         val refreshForces = mutableListOf<Boolean>()
 
         override fun loadApps(
@@ -529,6 +584,7 @@ class ExportViewModelTest {
 
         override suspend fun refreshCache(force: Boolean) {
             refreshForces += force
+            refreshBlock?.invoke()
             refreshError?.let { throw it }
         }
 

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/ExportViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/ExportViewModelTest.kt
@@ -62,7 +62,7 @@ class ExportViewModelTest {
             assertEquals(ExportFormat.XML, state.format)
             assertFalse(state.showArchived)
             assertFalse(state.isLoading)
-            assertEquals(listOf(true), repository.refreshForces)
+            assertTrue(repository.refreshForces.isEmpty())
         }
 
     @Test
@@ -75,6 +75,7 @@ class ExportViewModelTest {
             assertFalse(viewModel.uiState.value.loadFailed)
             assertEquals(0, viewModel.uiState.value.selectedCount)
             assertFalse(viewModel.uiState.value.canExport)
+            assertEquals(listOf(true), repository.refreshForces)
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/ExportViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/ExportViewModelTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -76,6 +77,46 @@ class ExportViewModelTest {
             assertEquals(0, viewModel.uiState.value.selectedCount)
             assertFalse(viewModel.uiState.value.canExport)
             assertEquals(listOf(true), repository.refreshForces)
+        }
+
+    @Test
+    fun `cache updates preserve existing choices exclude new apps and remove uninstalled apps`() =
+        runTest(dispatcher) {
+            repository.apps =
+                listOf(
+                    app("selected.app", "Selected"),
+                    app("deselected.app", "Deselected"),
+                    app("removed.app", "Removed"),
+                )
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            viewModel.toggleSelection("deselected.app")
+
+            repository.apps =
+                listOf(
+                    app("selected.app", "Selected updated"),
+                    app("deselected.app", "Deselected"),
+                    app("new.app", "New"),
+                )
+            advanceUntilIdle()
+
+            assertEquals(listOf("selected.app"), viewModel.appsForExport().map { it.packageName })
+            assertEquals("Selected updated", viewModel.appsForExport().single().name)
+            assertEquals(
+                listOf("deselected.app", "new.app", "selected.app"),
+                viewModel.uiState.value.visibleApps
+                    .map { it.packageName }
+                    .sorted(),
+            )
+            assertFalse(
+                viewModel.uiState.value.visibleApps
+                    .single { it.packageName == "new.app" }
+                    .isSelected,
+            )
+            assertFalse(
+                viewModel.uiState.value.visibleApps
+                    .any { it.packageName == "removed.app" },
+            )
         }
 
     @Test
@@ -465,7 +506,12 @@ class ExportViewModelTest {
         )
 
     private class FakeAppRepository : AppRepository {
-        var apps: List<App> = emptyList()
+        private val appsFlow = MutableStateFlow<List<App>>(emptyList())
+        var apps: List<App>
+            get() = appsFlow.value
+            set(value) {
+                appsFlow.value = value
+            }
         var refreshError: Exception? = null
         val refreshForces = mutableListOf<Boolean>()
 
@@ -478,6 +524,8 @@ class ExportViewModelTest {
         ): Flow<List<App>> = flowOf(apps)
 
         override fun getSyncState(): Flow<SyncState> = flowOf(SyncState.Idle)
+
+        override fun observeCachedApps(): Flow<List<App>> = appsFlow
 
         override suspend fun refreshCache(force: Boolean) {
             refreshForces += force


### PR DESCRIPTION
## Summary

- load cached apps immediately in the export activity and only force a refresh when the cache is empty
- configure export status-bar icons for the active light or dark theme
- add unit and instrumentation regression coverage

## Testing

- .\gradlew.bat ktlintCheck testDebugUnitTest
- .\gradlew.bat assembleDebugAndroidTest
- targeted ExportActivity status-bar instrumentation test on Android 16 emulator