### PR TITLE
Handle app list refresh failures

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -3,6 +3,7 @@ package com.github.keeganwitt.applist
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,14 +87,31 @@ class AppListViewModel(
         loadApps(reload = true)
     }
 
-    private var loadJob: kotlinx.coroutines.Job? = null
+    private var loadJob: Job? = null
+    private var summaryJob: Job? = null
+    private var cachedLoadOptions: LoadOptions? = null
     private var loadRequestId = 0L
 
     private fun loadApps(reload: Boolean) {
         val requestId = ++loadRequestId
         loadJob?.cancel()
+        summaryJob?.cancel()
         val state = _uiState.value
-        _uiState.update { it.copy(isLoading = true, loadFailed = false, isFullyLoaded = false, summary = null) }
+        val options =
+            LoadOptions(
+                state.selectedField,
+                state.systemAppsOnly,
+                state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
+                state.descending,
+            )
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                loadFailed = false,
+                isFullyLoaded = false,
+                summary = null,
+            )
+        }
 
         loadJob =
             viewModelScope.launch(dispatchers.io) {
@@ -101,10 +119,10 @@ class AppListViewModel(
                     loadMutex.withLock {
                         repository
                             .loadApps(
-                                field = state.selectedField,
-                                systemAppsOnly = state.systemAppsOnly,
-                                showArchivedApps = state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
-                                descending = state.descending,
+                                field = options.field,
+                                systemAppsOnly = options.systemAppsOnly,
+                                showArchivedApps = options.showArchivedApps,
+                                descending = options.descending,
                                 reload = reload,
                             ).collect { apps ->
                                 withContext(dispatchers.main) {
@@ -112,6 +130,7 @@ class AppListViewModel(
                                     val field = _uiState.value.selectedField
                                     cachedMappedItems = apps.map { mapToItem(it, field) }
                                     cachedMappedItemsField = field
+                                    cachedLoadOptions = options
                                     val fullyLoaded = apps.isEmpty() || apps.all { it.isDetailed }
                                     _uiState.update {
                                         it.copy(isLoading = false, loadFailed = false, isFullyLoaded = fullyLoaded)
@@ -124,8 +143,23 @@ class AppListViewModel(
                     if (exception is CancellationException) throw exception
                     withContext(dispatchers.main) {
                         if (requestId != loadRequestId) return@withContext
+                        val discardResults = options != cachedLoadOptions || options.field != cachedMappedItemsField
+                        if (discardResults) {
+                            summaryJob?.cancel()
+                            allApps = emptyList()
+                            cachedMappedItems = null
+                            cachedMappedItemsField = null
+                            cachedLoadOptions = null
+                        }
                         _uiState.update {
-                            it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                            it.copy(
+                                isLoading = false,
+                                loadFailed = true,
+                                isFullyLoaded = false,
+                                items = if (discardResults) emptyList() else it.items,
+                                filteredApps = if (discardResults) emptyList() else it.filteredApps,
+                                summary = null,
+                            )
                         }
                     }
                 }
@@ -133,7 +167,9 @@ class AppListViewModel(
     }
 
     private fun applyFilterAndEmit() {
+        summaryJob?.cancel()
         val state = _uiState.value
+        val apps = allApps
         if (cachedMappedItems == null || cachedMappedItemsField != state.selectedField) {
             cachedMappedItems = allApps.map { mapToItem(it, state.selectedField) }
             cachedMappedItemsField = state.selectedField
@@ -151,26 +187,27 @@ class AppListViewModel(
             }
         _uiState.update { it.copy(items = filtered) }
 
-        viewModelScope.launch(dispatchers.default) {
-            val filteredApps =
-                if (state.query.isBlank()) {
-                    allApps
-                } else {
-                    val filteredPackageNames = filtered.map { it.packageName }.toSet()
-                    allApps.filter { app -> app.packageName in filteredPackageNames }
-                }
+        summaryJob =
+            viewModelScope.launch(dispatchers.default) {
+                val filteredApps =
+                    if (state.query.isBlank()) {
+                        apps
+                    } else {
+                        val filteredPackageNames = filtered.map { it.packageName }.toSet()
+                        apps.filter { app -> app.packageName in filteredPackageNames }
+                    }
 
-            if (state.isFullyLoaded) {
-                val summary = summaryCalculator.calculate(filteredApps, state.selectedField)
-                withContext(dispatchers.main) {
-                    _uiState.update { it.copy(summary = summary, filteredApps = filteredApps) }
-                }
-            } else {
-                withContext(dispatchers.main) {
-                    _uiState.update { it.copy(summary = null, filteredApps = filteredApps) }
+                if (state.isFullyLoaded) {
+                    val summary = summaryCalculator.calculate(filteredApps, state.selectedField)
+                    withContext(dispatchers.main) {
+                        _uiState.update { it.copy(summary = summary, filteredApps = filteredApps) }
+                    }
+                } else {
+                    withContext(dispatchers.main) {
+                        _uiState.update { it.copy(summary = null, filteredApps = filteredApps) }
+                    }
                 }
             }
-        }
     }
 
     private fun mapToItem(
@@ -199,4 +236,11 @@ class AppListViewModel(
             isLoading = !app.isDetailed,
         )
     }
+
+    private data class LoadOptions(
+        val field: AppInfoField,
+        val systemAppsOnly: Boolean,
+        val showArchivedApps: Boolean,
+        val descending: Boolean,
+    )
 }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -87,8 +87,10 @@ class AppListViewModel(
     }
 
     private var loadJob: kotlinx.coroutines.Job? = null
+    private var loadRequestId = 0L
 
     private fun loadApps(reload: Boolean) {
+        val requestId = ++loadRequestId
         loadJob?.cancel()
         val state = _uiState.value
         _uiState.update { it.copy(isLoading = true, loadFailed = false, isFullyLoaded = false, summary = null) }
@@ -120,8 +122,11 @@ class AppListViewModel(
                     }
                 } catch (exception: Exception) {
                     if (exception is CancellationException) throw exception
-                    _uiState.update {
-                        it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                    withContext(dispatchers.main) {
+                        if (requestId != loadRequestId) return@withContext
+                        _uiState.update {
+                            it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -2,11 +2,14 @@ package com.github.keeganwitt.applist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 class AppListViewModel(
@@ -31,6 +34,7 @@ class AppListViewModel(
     private var allApps: List<App> = emptyList()
     private var cachedMappedItems: List<AppItemUiModel>? = null
     private var cachedMappedItemsField: AppInfoField? = null
+    private val loadMutex = Mutex()
 
     fun init(
         initialField: AppInfoField,
@@ -87,28 +91,39 @@ class AppListViewModel(
     private fun loadApps(reload: Boolean) {
         loadJob?.cancel()
         val state = _uiState.value
-        _uiState.update { it.copy(isLoading = true, isFullyLoaded = false, summary = null) }
+        _uiState.update { it.copy(isLoading = true, loadFailed = false, isFullyLoaded = false, summary = null) }
 
         loadJob =
             viewModelScope.launch(dispatchers.io) {
-                repository
-                    .loadApps(
-                        field = state.selectedField,
-                        systemAppsOnly = state.systemAppsOnly,
-                        showArchivedApps = state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
-                        descending = state.descending,
-                        reload = reload,
-                    ).collect { apps ->
-                        withContext(dispatchers.main) {
-                            allApps = apps
-                            val field = _uiState.value.selectedField
-                            cachedMappedItems = apps.map { mapToItem(it, field) }
-                            cachedMappedItemsField = field
-                            val fullyLoaded = apps.isEmpty() || apps.all { it.isDetailed }
-                            _uiState.update { it.copy(isLoading = false, isFullyLoaded = fullyLoaded) }
-                            applyFilterAndEmit()
-                        }
+                try {
+                    loadMutex.withLock {
+                        repository
+                            .loadApps(
+                                field = state.selectedField,
+                                systemAppsOnly = state.systemAppsOnly,
+                                showArchivedApps = state.showArchived || state.selectedField == AppInfoField.ARCHIVED,
+                                descending = state.descending,
+                                reload = reload,
+                            ).collect { apps ->
+                                withContext(dispatchers.main) {
+                                    allApps = apps
+                                    val field = _uiState.value.selectedField
+                                    cachedMappedItems = apps.map { mapToItem(it, field) }
+                                    cachedMappedItemsField = field
+                                    val fullyLoaded = apps.isEmpty() || apps.all { it.isDetailed }
+                                    _uiState.update {
+                                        it.copy(isLoading = false, loadFailed = false, isFullyLoaded = fullyLoaded)
+                                    }
+                                    applyFilterAndEmit()
+                                }
+                            }
                     }
+                } catch (exception: Exception) {
+                    if (exception is CancellationException) throw exception
+                    _uiState.update {
+                        it.copy(isLoading = false, loadFailed = true, isFullyLoaded = false, summary = null)
+                    }
+                }
             }
     }
 

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -29,6 +29,7 @@ import com.github.keeganwitt.applist.databinding.ActivityMainBinding
 import com.github.keeganwitt.applist.services.DefaultAppStoreService
 import com.github.keeganwitt.applist.utils.PermissionUtils
 import com.github.keeganwitt.applist.utils.nightMode
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.text.Collator
@@ -45,6 +46,7 @@ class MainActivity :
     private lateinit var fieldToLabelMap: Map<AppInfoField, String>
     private lateinit var appSettings: AppSettings
     private var latestState: UiState = UiState()
+    private var loadFailureSnackbar: Snackbar? = null
     private var shouldRefreshOnResume = false
     private var ignoreQueryChanges = false
     private var pendingField: AppInfoField? = null
@@ -194,9 +196,25 @@ class MainActivity :
                         ignoreQueryChanges = true
                         invalidateOptionsMenu()
                     }
+                    updateLoadFailureUi(state.loadFailed)
                     updateSyncUi(state.syncState)
                 }
             }
+        }
+    }
+
+    private fun updateLoadFailureUi(loadFailed: Boolean) {
+        if (loadFailed) {
+            if (loadFailureSnackbar?.isShown != true) {
+                loadFailureSnackbar =
+                    Snackbar
+                        .make(binding.root, R.string.loading_failed, Snackbar.LENGTH_INDEFINITE)
+                        .setAction(R.string.export_retry) { appListViewModel.refresh() }
+                        .also(Snackbar::show)
+            }
+        } else {
+            loadFailureSnackbar?.dismiss()
+            loadFailureSnackbar = null
         }
     }
 

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/UiState.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/UiState.kt
@@ -7,6 +7,7 @@ data class UiState(
     val descending: Boolean = false,
     val query: String = "",
     val isLoading: Boolean = false,
+    val loadFailed: Boolean = false,
     val isFullyLoaded: Boolean = false,
     val items: List<AppItemUiModel> = emptyList(),
     val filteredApps: List<App> = emptyList(),

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
@@ -996,6 +997,214 @@ class AppListViewModelTest {
             assertFalse(state.isFullyLoaded)
             assertTrue(state.loadFailed)
             assertTrue(state.items.isEmpty())
+        }
+
+    @Test
+    fun `given cached apps, when changed options fail before emitting, then old results are cleared`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            val changes =
+                listOf<Pair<String, () -> Unit>>(
+                    "field" to { viewModel.updateSelectedField(AppInfoField.ENABLED) },
+                    "sort" to { viewModel.setDescending(true) },
+                    "system apps" to { viewModel.setSystemAppsOnly(true) },
+                    "archived apps" to { viewModel.setShowArchived(true) },
+                    "initial options" to { viewModel.init(AppInfoField.ARCHIVED, true, true, true) },
+                )
+
+            for ((name, change) in changes) {
+                coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(cachedApp))
+                viewModel.init(AppInfoField.VERSION, false, false, false)
+                advanceUntilIdle()
+                assertEquals(
+                    listOf("1.2.3"),
+                    viewModel.uiState.value.items
+                        .map { it.infoText },
+                )
+
+                coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                    flow { throw IllegalStateException("replacement failed") }
+                change()
+                advanceUntilIdle()
+
+                val state = viewModel.uiState.value
+                assertTrue(name, state.loadFailed)
+                assertFalse(name, state.isLoading)
+                assertTrue(name, state.items.isEmpty())
+                assertTrue(name, state.filteredApps.isEmpty())
+                assertNull(name, state.summary)
+
+                viewModel.setQuery("Cached")
+                advanceUntilIdle()
+                assertTrue(
+                    name,
+                    viewModel.uiState.value.items
+                        .isEmpty(),
+                )
+                assertTrue(
+                    name,
+                    viewModel.uiState.value.filteredApps
+                        .isEmpty(),
+                )
+                viewModel.setQuery("")
+                advanceUntilIdle()
+                assertTrue(
+                    name,
+                    viewModel.uiState.value.items
+                        .isEmpty(),
+                )
+            }
+        }
+
+    @Test
+    fun `given field change still loading, when refresh replaces it and fails, then original rows are cleared`() =
+        runTest {
+            val app = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flow { awaitCancellation() }
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement refresh failed") }
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertEquals(AppInfoField.ENABLED, viewModel.uiState.value.selectedField)
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertTrue(
+                viewModel.uiState.value.items
+                    .isEmpty(),
+            )
+            assertTrue(
+                viewModel.uiState.value.filteredApps
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `given cached rows remapped during loading, when returning to original field fails, then remapped rows are cleared`() =
+        runTest {
+            val app = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flow { awaitCancellation() }
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+            viewModel.setQuery("Cached")
+            advanceUntilIdle()
+            assertEquals(
+                listOf("true"),
+                viewModel.uiState.value.items
+                    .map { it.infoText },
+            )
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement failed") }
+            viewModel.updateSelectedField(AppInfoField.VERSION)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(AppInfoField.VERSION, state.selectedField)
+            assertTrue(state.loadFailed)
+            assertTrue(state.items.isEmpty())
+            assertTrue(state.filteredApps.isEmpty())
+        }
+
+    @Test
+    fun `given cached apps, when unchanged refresh fails before emitting, then cached results remain`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(cachedApp))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+            val cachedItems = viewModel.uiState.value.items
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("refresh failed") }
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertEquals(cachedItems, viewModel.uiState.value.items)
+            assertEquals(listOf(cachedApp), viewModel.uiState.value.filteredApps)
+        }
+
+    @Test
+    fun `given changed field failed, when retry emits then fails, then only replacement results remain`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App", versionName = "1.2.3")
+            val replacementApp = createTestApp("com.replacement.app", "Replacement App")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(cachedApp))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            advanceUntilIdle()
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement failed") }
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            advanceUntilIdle()
+            assertEquals(AppInfoField.ENABLED, viewModel.uiState.value.selectedField)
+            assertTrue(
+                viewModel.uiState.value.items
+                    .isEmpty(),
+            )
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow {
+                    emit(listOf(replacementApp))
+                    throw IllegalStateException("sync failed")
+                }
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertEquals(
+                listOf("com.replacement.app"),
+                viewModel.uiState.value.items
+                    .map { it.packageName },
+            )
+            assertEquals(
+                listOf("true"),
+                viewModel.uiState.value.items
+                    .map { it.infoText },
+            )
+        }
+
+    @Test
+    fun `given pending summary, when option change fails, then stale summary cannot restore cleared results`() =
+        runTest {
+            val summaryScheduler = TestCoroutineScheduler()
+            val provider =
+                object : DispatcherProvider {
+                    override val io = testDispatcher
+                    override val main = testDispatcher
+                    override val default = StandardTestDispatcher(summaryScheduler)
+                }
+            viewModel = AppListViewModel(repository, provider, summaryCalculator, { it.toString() }, "Unknown", "Failed")
+            val app = createTestApp("com.cached.app", "Cached App", isDetailed = true)
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+            viewModel.init(AppInfoField.VERSION, false, false, false)
+            runCurrent()
+            assertEquals(1, viewModel.uiState.value.items.size)
+
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("replacement failed") }
+            viewModel.setDescending(true)
+            runCurrent()
+            summaryScheduler.runCurrent()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.loadFailed)
+            assertNull(viewModel.uiState.value.summary)
+            assertTrue(
+                viewModel.uiState.value.filteredApps
+                    .isEmpty(),
+            )
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -995,6 +996,49 @@ class AppListViewModelTest {
             assertFalse(state.isFullyLoaded)
             assertTrue(state.loadFailed)
             assertTrue(state.items.isEmpty())
+        }
+
+    @Test
+    fun `given canceled producer throws, when replacement awaits results, then loading state belongs to replacement`() =
+        runTest {
+            val replacementResult = CompletableDeferred<List<App>>()
+            var loadCount = 0
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } answers {
+                loadCount++
+                if (loadCount == 1) {
+                    channelFlow {
+                        try {
+                            awaitCancellation()
+                        } finally {
+                            throw IllegalStateException("canceled producer failed")
+                        }
+                    }
+                } else {
+                    flow { emit(replacementResult.await()) }
+                }
+            }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            runCurrent()
+
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+            val pendingState = viewModel.uiState.value
+
+            replacementResult.complete(listOf(createTestApp("com.replacement.app", "Replacement")))
+            advanceUntilIdle()
+
+            assertEquals(2, loadCount)
+            assertTrue(pendingState.isLoading)
+            assertFalse(pendingState.loadFailed)
+            val completedState = viewModel.uiState.value
+            assertFalse(completedState.loadFailed)
+            assertEquals(listOf("com.replacement.app"), completedState.items.map { it.packageName })
         }
 
     @Test

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -5,8 +5,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -14,6 +18,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -969,6 +974,100 @@ class AppListViewModelTest {
                 @Suppress("UnusedFlow")
                 repository.loadApps(any(), any(), any(), any(), any())
             }
+        }
+
+    @Test
+    fun `given load fails before emitting apps, when initialized, then failure is exposed`() =
+        runTest {
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow { throw IllegalStateException("load failed") }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isLoading)
+            assertFalse(state.isFullyLoaded)
+            assertTrue(state.loadFailed)
+            assertTrue(state.items.isEmpty())
+        }
+
+    @Test
+    fun `given load fails after emitting cached apps, when initialized, then apps remain visible with failure`() =
+        runTest {
+            val cachedApp = createTestApp("com.cached.app", "Cached App")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns
+                flow {
+                    emit(listOf(cachedApp))
+                    throw IllegalStateException("refresh failed")
+                }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isLoading)
+            assertFalse(state.isFullyLoaded)
+            assertTrue(state.loadFailed)
+            assertEquals(listOf("com.cached.app"), state.items.map { it.packageName })
+        }
+
+    @Test
+    fun `given canceled load is still cleaning up, when load is replaced, then replacement waits`() =
+        runTest {
+            val cleanupStarted = CompletableDeferred<Unit>()
+            val allowCleanup = CompletableDeferred<Unit>()
+            val replacementStarted = CompletableDeferred<Unit>()
+            var loadCount = 0
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } answers {
+                loadCount++
+                if (loadCount == 1) {
+                    flow {
+                        try {
+                            awaitCancellation()
+                        } finally {
+                            withContext(NonCancellable) {
+                                cleanupStarted.complete(Unit)
+                                allowCleanup.await()
+                            }
+                        }
+                    }
+                } else {
+                    flow {
+                        replacementStarted.complete(Unit)
+                        emit(emptyList())
+                    }
+                }
+            }
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            runCurrent()
+
+            viewModel.updateSelectedField(AppInfoField.ENABLED)
+            runCurrent()
+
+            assertTrue(cleanupStarted.isCompleted)
+            assertFalse(replacementStarted.isCompleted)
+
+            allowCleanup.complete(Unit)
+            advanceUntilIdle()
+
+            assertTrue(replacementStarted.isCompleted)
         }
 
     @Test


### PR DESCRIPTION
## Summary

- serialize app-list load replacements so canceled refreshes finish cleanup before a replacement starts
- preserve cached results and expose repository load failures through UI state
- show a persistent retry Snackbar when app loading fails
- add regression coverage for pre-emission failures, partial-result failures, and cancellation cleanup

## Testing

- `.\gradlew.bat ktlintCheck testDebugUnitTest assembleDebugAndroidTest --rerun-tasks`