### PR TITLE
Add app store links to app cards

### DIFF
--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppAdapter.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppAdapter.kt
@@ -50,6 +50,24 @@ class AppAdapter(
         binding.appName.text = item.appName
         bindAppInfo(binding.appInfo, item)
         binding.appInfo.visibility = if (item.infoText.isBlank()) View.GONE else View.VISIBLE
+        bindStoreLink(binding, item)
+    }
+
+    private fun bindStoreLink(
+        binding: SnippetListRowBinding,
+        item: AppItemUiModel,
+    ) {
+        val storeUrl = item.storeUrl
+        if (storeUrl == null) {
+            binding.storeLink.visibility = View.GONE
+            binding.storeLink.setOnClickListener(null)
+            return
+        }
+
+        binding.storeLink.visibility = View.VISIBLE
+        binding.storeLink.contentDescription =
+            binding.root.context.getString(R.string.open_in_app_store_description, item.appName)
+        binding.storeLink.setOnClickListener { onClickListener.onStoreUrlClick(storeUrl) }
     }
 
     private fun bindAppInfo(

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppItemUiModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppItemUiModel.kt
@@ -5,5 +5,6 @@ data class AppItemUiModel(
     val appName: String,
     val infoText: String,
     val infoUrl: String? = null,
+    val storeUrl: String? = null,
     val isLoading: Boolean = false,
 )

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -233,6 +233,7 @@ class AppListViewModel(
             appName = app.name,
             infoText = info,
             infoUrl = info.takeIf { field == AppInfoField.STORE_URL && it.isNotBlank() },
+            storeUrl = app.storeUrl,
             isLoading = !app.isDetailed,
         )
     }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -214,10 +214,13 @@ class AppListViewModel(
         app: App,
         field: AppInfoField,
     ): AppItemUiModel {
+        val storeUrl = app.storeUrl?.takeIf { it.isNotBlank() }
         val rawValue = field.getValue(app)
         val info =
             if (field == AppInfoField.APP_NAME || field == AppInfoField.PACKAGE_NAME) {
                 ""
+            } else if (field == AppInfoField.STORE_URL) {
+                storeUrl ?: unknownValue
             } else if (field in app.failedFields) {
                 loadingFailedValue
             } else if (field.isSize &&
@@ -232,8 +235,8 @@ class AppListViewModel(
             packageName = app.packageName,
             appName = app.name,
             infoText = info,
-            infoUrl = app.storeUrl?.takeIf { field == AppInfoField.STORE_URL && it.isNotBlank() },
-            storeUrl = app.storeUrl,
+            infoUrl = storeUrl?.takeIf { field == AppInfoField.STORE_URL },
+            storeUrl = storeUrl,
             isLoading = !app.isDetailed,
         )
     }

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/AppListViewModel.kt
@@ -232,7 +232,7 @@ class AppListViewModel(
             packageName = app.packageName,
             appName = app.name,
             infoText = info,
-            infoUrl = info.takeIf { field == AppInfoField.STORE_URL && it.isNotBlank() },
+            infoUrl = app.storeUrl?.takeIf { field == AppInfoField.STORE_URL && it.isNotBlank() },
             storeUrl = app.storeUrl,
             isLoading = !app.isDetailed,
         )

--- a/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/keeganwitt/applist/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.github.keeganwitt.applist
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
@@ -299,7 +300,11 @@ class MainActivity :
     }
 
     override fun onStoreUrlClick(url: String) {
-        startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+        } catch (_: ActivityNotFoundException) {
+            Toast.makeText(this, R.string.app_store_unavailable, Toast.LENGTH_SHORT).show()
+        }
     }
 
     override fun onItemSelected(

--- a/app/src/main/res/drawable/ic_store.xml
+++ b/app/src/main/res/drawable/ic_store.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,4H4v2h16V4zM21,14v-2l-1,-5H4l-1,5v2h1v6h10v-6h4v6h2v-6h1zM12,18H6v-4h6v4z" />
+</vector>

--- a/app/src/main/res/layout/snippet_list_row.xml
+++ b/app/src/main/res/layout/snippet_list_row.xml
@@ -44,4 +44,13 @@
     android:layout_height="wrap_content"
     android:gravity="center_horizontal" />
 
+  <ImageButton
+    android:id="@+id/store_link"
+    style="?android:attr/borderlessButtonStyle"
+    android:layout_width="48dp"
+    android:layout_height="48dp"
+    android:contentDescription="@string/open_in_app_store"
+    android:src="@drawable/ic_store"
+    android:visibility="gone" />
+
 </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">جاري بناء ذاكرة التخزين المؤقت الأولية…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">رابط المتجر</string>
+    <string name="open_in_app_store">فتح في متجر التطبيقات</string>
+    <string name="open_in_app_store_description">فتح %1$s في متجر التطبيقات</string>
+    <string name="app_store_unavailable">لا يمكن لأي متجر تطبيقات أو متصفح فتح هذا الرابط</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">正在建立初始缓存…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">店铺网址</string>
+    <string name="open_in_app_store">在应用商店中打开</string>
+    <string name="open_in_app_store_description">在应用商店中打开 %1$s</string>
+    <string name="app_store_unavailable">没有应用商店或浏览器可以打开此链接</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">正在建立初始快取…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">店鋪網址</string>
+    <string name="open_in_app_store">在應用程式商店中開啟</string>
+    <string name="open_in_app_store_description">在應用程式商店中開啟 %1$s</string>
+    <string name="app_store_unavailable">沒有應用程式商店或瀏覽器可以開啟此連結</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">প্রাথমিক ক্যাশ তৈরি হচ্ছে…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">স্টোর ইউআরएल</string>
+    <string name="open_in_app_store">অ্যাপ স্টোরে খুলুন</string>
+    <string name="open_in_app_store_description">অ্যাপ স্টোরে %1$s খুলুন</string>
+    <string name="app_store_unavailable">কোনো অ্যাপ স্টোর বা ব্রাউজার এই লিঙ্কটি খুলতে পারে না</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -59,4 +59,7 @@
     <string name="building_initial_cache">Vytváření počáteční mezipaměti…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">Adresa URL obchodu</string>
+    <string name="open_in_app_store">Otevřít v obchodě s aplikacemi</string>
+    <string name="open_in_app_store_description">Otevřít %1$s v obchodě s aplikacemi</string>
+    <string name="app_store_unavailable">Tento odkaz nelze otevřít v žádném obchodě s aplikacemi ani prohlížeči</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Initialer Cache wird aufgebaut…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">Store-URL</string>
+    <string name="open_in_app_store">Im App-Store öffnen</string>
+    <string name="open_in_app_store_description">%1$s im App-Store öffnen</string>
+    <string name="app_store_unavailable">Kein App-Store oder Browser kann diesen Link öffnen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Creando caché inicial…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL de la tienda</string>
+    <string name="open_in_app_store">Abrir en la tienda de aplicaciones</string>
+    <string name="open_in_app_store_description">Abrir %1$s en la tienda de aplicaciones</string>
+    <string name="app_store_unavailable">Ninguna tienda de aplicaciones ni navegador puede abrir este enlace</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">در حال ساخت کش اولیه…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">نشانی اینترنتی فروشگاه</string>
+    <string name="open_in_app_store">باز کردن در فروشگاه برنامه</string>
+    <string name="open_in_app_store_description">باز کردن %1$s در فروشگاه برنامه</string>
+    <string name="app_store_unavailable">هیچ فروشگاه برنامه یا مرورگری نمی‌تواند این پیوند را باز کند</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Création du cache initial…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL de la boutique</string>
+    <string name="open_in_app_store">Ouvrir dans la boutique d’applications</string>
+    <string name="open_in_app_store_description">Ouvrir %1$s dans la boutique d’applications</string>
+    <string name="app_store_unavailable">Aucune boutique d’applications ni aucun navigateur ne peut ouvrir ce lien</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">प्रारंभिक कैश बनाया जा रहा है…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">स्टोर यूआरएल</string>
+    <string name="open_in_app_store">ऐप स्टोर में खोलें</string>
+    <string name="open_in_app_store_description">%1$s को ऐप स्टोर में खोलें</string>
+    <string name="app_store_unavailable">कोई ऐप स्टोर या ब्राउज़र इस लिंक को नहीं खोल सकता</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Membangun cache awal…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL Toko</string>
+    <string name="open_in_app_store">Buka di toko aplikasi</string>
+    <string name="open_in_app_store_description">Buka %1$s di toko aplikasi</string>
+    <string name="app_store_unavailable">Tidak ada toko aplikasi atau browser yang dapat membuka tautan ini</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Creazione della cache iniziale…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL del negozio</string>
+    <string name="open_in_app_store">Apri nello store di app</string>
+    <string name="open_in_app_store_description">Apri %1$s nello store di app</string>
+    <string name="app_store_unavailable">Nessuno store di app o browser può aprire questo link</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">בונה מטמון ראשוני…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">כתובת URL של החנות</string>
+    <string name="open_in_app_store">פתיחה בחנות האפליקציות</string>
+    <string name="open_in_app_store_description">פתיחת %1$s בחנות האפליקציות</string>
+    <string name="app_store_unavailable">אין חנות אפליקציות או דפדפן שיכולים לפתוח את הקישור הזה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">初期キャッシュを構築中…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">ストアURL</string>
+    <string name="open_in_app_store">アプリストアで開く</string>
+    <string name="open_in_app_store_description">%1$s をアプリストアで開く</string>
+    <string name="app_store_unavailable">このリンクを開けるアプリストアまたはブラウザがありません</string>
 </resources>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -59,4 +59,7 @@
     <string name="building_initial_cache">Бастапқы кэш жасалуда…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">Дүкен URL мекенжайы</string>
+    <string name="open_in_app_store">Қолданбалар дүкенінде ашу</string>
+    <string name="open_in_app_store_description">%1$s қолданбасын қолданбалар дүкенінде ашу</string>
+    <string name="app_store_unavailable">Бұл сілтемені ешбір қолданбалар дүкені немесе браузер аша алмайды</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">초기 캐시 구축 중…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">스토어 URL</string>
+    <string name="open_in_app_store">앱 스토어에서 열기</string>
+    <string name="open_in_app_store_description">앱 스토어에서 %1$s 열기</string>
+    <string name="app_store_unavailable">이 링크를 열 수 있는 앱 스토어나 브라우저가 없습니다</string>
 </resources>

--- a/app/src/main/res/values-kw/strings.xml
+++ b/app/src/main/res/values-kw/strings.xml
@@ -59,4 +59,7 @@
     <string name="building_initial_cache">O kila kuddhas kynsa…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL Shoppa</string>
+    <string name="open_in_app_store">Ygeri yn shoppa app</string>
+    <string name="open_in_app_store_description">Ygeri %1$s yn shoppa app</string>
+    <string name="app_store_unavailable">Nyns eus shoppa app po peurell a yll ygeri an kevren ma</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Eerste cache opbouwen…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">Winkel-URL</string>
+    <string name="open_in_app_store">Openen in appwinkel</string>
+    <string name="open_in_app_store_description">%1$s openen in appwinkel</string>
+    <string name="app_store_unavailable">Geen appwinkel of browser kan deze link openen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Budowanie początkowej pamięci podręcznej…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">Adres URL sklepu</string>
+    <string name="open_in_app_store">Otwórz w sklepie z aplikacjami</string>
+    <string name="open_in_app_store_description">Otwórz %1$s w sklepie z aplikacjami</string>
+    <string name="app_store_unavailable">Żaden sklep z aplikacjami ani przeglądarka nie może otworzyć tego linku</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Construindo cache inicial…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL da loja</string>
+    <string name="open_in_app_store">Abrir na loja de aplicativos</string>
+    <string name="open_in_app_store_description">Abrir %1$s na loja de aplicativos</string>
+    <string name="app_store_unavailable">Nenhuma loja de aplicativos ou navegador pode abrir este link</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Создание начального кэша…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL магазина</string>
+    <string name="open_in_app_store">Открыть в магазине приложений</string>
+    <string name="open_in_app_store_description">Открыть %1$s в магазине приложений</string>
+    <string name="app_store_unavailable">Ни один магазин приложений или браузер не может открыть эту ссылку</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">กำลังสร้างแคชเริ่มต้น…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL ร้านค้า</string>
+    <string name="open_in_app_store">เปิดในร้านค้าแอป</string>
+    <string name="open_in_app_store_description">เปิด %1$s ในร้านค้าแอป</string>
+    <string name="app_store_unavailable">ไม่มีร้านค้าแอปหรือเบราว์เซอร์ที่สามารถเปิดลิงก์นี้ได้</string>
 </resources>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Binubuo ang initial cache…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL ng Store</string>
+    <string name="open_in_app_store">Buksan sa app store</string>
+    <string name="open_in_app_store_description">Buksan ang %1$s sa app store</string>
+    <string name="app_store_unavailable">Walang app store o browser na maaaring magbukas ng link na ito</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">İlk önbellek oluşturuluyor…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">Mağaza URL\'si</string>
+    <string name="open_in_app_store">Uygulama mağazasında aç</string>
+    <string name="open_in_app_store_description">%1$s uygulamasını uygulama mağazasında aç</string>
+    <string name="app_store_unavailable">Bu bağlantıyı açabilecek bir uygulama mağazası veya tarayıcı yok</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Створення початкового кешу…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL магазину</string>
+    <string name="open_in_app_store">Відкрити в магазині застосунків</string>
+    <string name="open_in_app_store_description">Відкрити %1$s у магазині застосунків</string>
+    <string name="app_store_unavailable">Жоден магазин застосунків або браузер не може відкрити це посилання</string>
 </resources>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">ابتدائی کیشے بنایا جا رہا ہے…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">اسٹور کا URL</string>
+    <string name="open_in_app_store">ایپ اسٹور میں کھولیں</string>
+    <string name="open_in_app_store_description">%1$s کو ایپ اسٹور میں کھولیں</string>
+    <string name="app_store_unavailable">کوئی ایپ اسٹور یا براؤزر یہ لنک نہیں کھول سکتا</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -58,4 +58,7 @@
     <string name="building_initial_cache">Đang xây dựng bộ nhớ đệm ban đầu…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">URL cửa hàng</string>
+    <string name="open_in_app_store">Mở trong cửa hàng ứng dụng</string>
+    <string name="open_in_app_store_description">Mở %1$s trong cửa hàng ứng dụng</string>
+    <string name="app_store_unavailable">Không có cửa hàng ứng dụng hoặc trình duyệt nào có thể mở liên kết này</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,7 @@
     <string name="building_initial_cache">Building initial cache…</string>
     <string name="sync_progress">%1$d / %2$d</string>
     <string name="appInfoField_storeUrl">Store URL</string>
+    <string name="open_in_app_store">Open in app store</string>
+    <string name="open_in_app_store_description">Open %1$s in app store</string>
+    <string name="app_store_unavailable">No app store or browser can open this link</string>
 </resources>

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppAdapterTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppAdapterTest.kt
@@ -2,6 +2,7 @@ package com.github.keeganwitt.applist
 
 import android.text.Spanned
 import android.text.style.ClickableSpan
+import android.view.View
 import android.widget.FrameLayout
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.mockk
@@ -90,6 +91,29 @@ class AppAdapterTest {
 
         assertTrue(holder.binding.appInfo.isClickable)
         verify { onClickListener.onStoreUrlClick(url) }
+    }
+
+    @Test
+    fun `given item with store URL, when bound and store button clicked, then store URL click is reported`() {
+        val url = "https://play.google.com/store/apps/details?id=com.test.app"
+        val holder = createViewHolder()
+        adapter.submitList(listOf(AppItemUiModel("com.test.app", "App", "1.0.0", storeUrl = url)))
+
+        adapter.onBindViewHolder(holder, 0)
+        holder.binding.storeLink.performClick()
+
+        assertEquals(View.VISIBLE, holder.binding.storeLink.visibility)
+        verify { onClickListener.onStoreUrlClick(url) }
+    }
+
+    @Test
+    fun `given item without store URL, when bound, then store button is hidden`() {
+        val holder = createViewHolder()
+        adapter.submitList(listOf(AppItemUiModel("com.test.app", "App", "1.0.0")))
+
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals(View.GONE, holder.binding.storeLink.visibility)
     }
 
     private fun createViewHolder(): AppAdapter.AppInfoViewHolder {

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -360,6 +360,26 @@ class AppListViewModelTest {
         }
 
     @Test
+    fun `given app has store URL, when another field is selected, then store action URL is retained`() =
+        runTest {
+            val storeUrl = "https://play.google.com/store/apps/details?id=com.test.app"
+            val app = createTestApp("com.test.app", "Test App").copy(storeUrl = storeUrl)
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+
+            viewModel.init(
+                AppInfoField.VERSION,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val item = viewModel.uiState.value.items[0]
+            assertEquals("1.0.0", item.infoText)
+            assertEquals(storeUrl, item.storeUrl)
+        }
+
+    @Test
     fun `given size field, when mapToItem called, then sizeFormatter is used`() =
         runTest {
             val app = createTestApp("com.test.app", "Test App").copy(sizes = StorageUsage(apkBytes = 1024))

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -360,6 +360,25 @@ class AppListViewModelTest {
         }
 
     @Test
+    fun `given unknown store URL, when store URL field is selected, then unknown text is not a link`() =
+        runTest {
+            val app = createTestApp("com.test.app", "Test App").copy(storeUrl = null)
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+
+            viewModel.init(
+                AppInfoField.STORE_URL,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val item = viewModel.uiState.value.items[0]
+            assertEquals("Unknown", item.infoText)
+            assertEquals(null, item.infoUrl)
+        }
+
+    @Test
     fun `given app has store URL, when another field is selected, then store action URL is retained`() =
         runTest {
             val storeUrl = "https://play.google.com/store/apps/details?id=com.test.app"

--- a/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/keeganwitt/applist/AppListViewModelTest.kt
@@ -379,6 +379,26 @@ class AppListViewModelTest {
         }
 
     @Test
+    fun `given blank store URL, when store URL field is selected, then no store links are exposed`() =
+        runTest {
+            val app = createTestApp("com.test.app", "Test App").copy(storeUrl = "")
+            coEvery { repository.loadApps(any(), any(), any(), any(), any()) } returns flowOf(listOf(app))
+
+            viewModel.init(
+                AppInfoField.STORE_URL,
+                initialSystemAppsOnly = false,
+                initialShowArchived = false,
+                initialDescending = false,
+            )
+            advanceUntilIdle()
+
+            val item = viewModel.uiState.value.items[0]
+            assertEquals("Unknown", item.infoText)
+            assertEquals(null, item.infoUrl)
+            assertEquals(null, item.storeUrl)
+        }
+
+    @Test
     fun `given app has store URL, when another field is selected, then store action URL is retained`() =
         runTest {
             val storeUrl = "https://play.google.com/store/apps/details?id=com.test.app"


### PR DESCRIPTION
Adds a persistent app-store action to eligible app cards while preserving the existing App info behavior. Reuses installer-specific store URLs, hides the action when unavailable, handles missing link handlers, includes localized accessibility text, and adds regression coverage. Verification: ./gradlew ktlintCheck lintDebug test assembleDebug.